### PR TITLE
TECH-169: Add mock applications to bb-identity

### DIFF
--- a/examples/mock/Dockerfile
+++ b/examples/mock/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine
+
+RUN npm install -g @mockoon/cli@2.2.1
+COPY mockoon-bbidentity.json ./mockoon-bbidentity.json
+
+# Do not run as root.
+RUN adduser --shell /bin/sh --disabled-password --gecos "" mockoon
+RUN chown -R mockoon ./mockoon-bbidentity.json
+USER mockoon
+
+EXPOSE 3003
+
+ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", "mockoon-bbidentity.json", "--container"]
+
+# Usage: docker run -p <host_port>:<container_port> mockoon-test

--- a/examples/mock/README.md
+++ b/examples/mock/README.md
@@ -1,0 +1,20 @@
+# Mockoon API
+
+This is a mock application which performs the whole OpenAPI spec for Identity BB
+
+## Setup
+
+To run dockerized version of mocked API use shell script `test_entrypoint.sh`
+(requires `docker` and `docker-compose`). By default, API is available on port
+`3344`, application runs on port `3003` in Docker host. Dockerfile was created
+using mockoon-cli.
+
+## Changes in API definition
+
+To introduce changes in API definition it is necessary to change content of
+`mockoon-bbidentity.json` file. It can be done using
+[mockoon application](https://mockoon.com/). After following instalation, API
+Spec can be opened from application navigation bar
+`File > Open environment > Select mockoon-bbidentity.json`. Dockerized
+instance of application is not hot-reloaded, therefore it's necessary to restart
+server for changes to be applied.

--- a/examples/mock/docker-compose.yml
+++ b/examples/mock/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.3"
+
+services:
+  app:
+    image: bb-identity-api-image
+    ports:
+      - 3344:3003
+    networks:
+      - web
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./mockoon-bbidentity.json:/mockoon-bbidentity.json
+
+networks:
+  web:
+    driver: bridge

--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -1,0 +1,42 @@
+{
+  "uuid": "256918d8-70c9-4e45-ad37-a6cb1a3f39f7",
+  "lastMigration": 24,
+  "name": "Mockoon bbidentity",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3003,
+  "hostname": "0.0.0.0",
+  "routes": [],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": []
+}

--- a/examples/mock/test_entrypoint.sh
+++ b/examples/mock/test_entrypoint.sh
@@ -1,0 +1,1 @@
+docker-compose up app


### PR DESCRIPTION
Generic mockoon API that is being generated based on openAPI schema was created in digital-registries building block. This example application should be copied to the bb-identity building blocks.

TICKET: https://govstack-global.atlassian.net/browse/TECH-169