### PR TITLE
TECH-134: Create test configuration for "/authorize" endpoint

### DIFF
--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -6,7 +6,110 @@
   "latency": 0,
   "port": 3003,
   "hostname": "0.0.0.0",
-  "routes": [],
+  "routes": [
+    {
+      "uuid": "f90e90b4-866f-478f-b34c-a358d8196f01",
+      "documentation": "The authorize endpoint of Open ID Connect (OIDC)",
+      "method": "get",
+      "endpoint": "authorize",
+      "responses": [
+        {
+          "uuid": "bf45f01a-d052-430c-8a88-ea4524b29f69",
+          "body": "",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Successfully loads JS application, and validates the provided query parameters using oauth-details endpoint",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "scope",
+              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^office_access$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "response_type",
+              "value": "code",
+              "invert": false,
+              "operator": "equals"
+            },
+            {
+              "target": "query",
+              "modifier": "client_id",
+              "value": "^.{1,}$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "redirect_uri",
+              "value": "^.{1,}$",
+              "invert": false,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        },
+        {
+          "uuid": "12e4ba89-6dfb-4c15-a632-9a3158dcfb26",
+          "body": "",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Invalid request",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "scope",
+              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^office_access$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "response_type",
+              "value": "code",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "query",
+              "modifier": "client_id",
+              "value": "^.{1,}$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "redirect_uri",
+              "value": "^.{1,}$",
+              "invert": true,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    }
+  ],
   "proxyMode": false,
   "proxyHost": "",
   "proxyRemovePrefix": false,

--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -295,7 +295,7 @@
             {
               "target": "query",
               "modifier": "scope",
-              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^office_access$",
+              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^offline_access$",
               "invert": false,
               "operator": "regex"
             },
@@ -341,7 +341,7 @@
             {
               "target": "query",
               "modifier": "scope",
-              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^office_access$",
+              "value": "^openid profile$|^openid$|^profile$|^email$|^address$|^phone$|^offline_access$",
               "invert": true,
               "operator": "regex"
             },

--- a/test/features/oidc_authorize.feature
+++ b/test/features/oidc_authorize.feature
@@ -1,0 +1,36 @@
+Feature: The authorize endpoint of Open ID Connect (OIDC).
+
+  This is the authorize endpoint of Open ID Connect (OIDC), the relying party applications will do a browser redirect
+  to this endpoint with all required details passed as query parameters.
+
+  Request endpoint: GET /authorize
+
+  Scenario: Successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint
+    When The user triggers an action with every required parameters
+    Then The user successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
+
+  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid scope parameter
+    When The user triggers an action with an invalid scope parameter
+    Then The result of an operation returns an error, because of an invalid scope provided
+
+  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid response_type provided
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid response_type parameter
+    When The user triggers an action with an invalid response_type parameter
+    Then The result of an operation returns an error, because of an invalid response_type provided
+
+  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid client_id provided
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid client_id parameter
+    When The user triggers an action with an invalid client_id parameter
+    Then The result of an operation returns an error, because of an invalid client_id provided
+
+  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid redirect_uri provided
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid redirect_uri parameter
+    When The user triggers an action with an invalid redirect_uri parameter
+    Then The result of an operation returns an error, because of an invalid redirect_uri provided
+
+  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because none parameters provided
+    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint without parameters
+    When The user triggers an action without parameters
+    Then The result of an operation returns an error, because none parameters provided

--- a/test/features/oidc_authorize.feature
+++ b/test/features/oidc_authorize.feature
@@ -1,36 +1,36 @@
-Feature: The authorize endpoint of Open ID Connect (OIDC).
+Feature: The authorized endpoint of Open ID Connect (OIDC).
 
-  This is the authorize endpoint of Open ID Connect (OIDC), the relying party applications will do a browser redirect
+  This is the authorized endpoint of Open ID Connect (OIDC), the relying party applications will do a browser redirect
   to this endpoint with all required details passed as query parameters.
 
   Request endpoint: GET /authorize
 
-  Scenario: Successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint
-    When The user triggers an action with every required parameters
-    Then The user successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
+  Scenario: Successfully loads the JS application and validates the provided query parameters using the OAuth-details endpoint
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint
+    When The user triggers an action with every required parameter
+    Then The user successfully loads the JS application and validates the provided query parameters using the OAuth-details endpoint
 
-  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid scope parameter
+  Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid scope provided
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid scope parameter
     When The user triggers an action with an invalid scope parameter
-    Then The result of an operation returns an error, because of an invalid scope provided
+    Then The result of an operation returns an error because of an invalid scope provided
 
-  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid response_type provided
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid response_type parameter
+  Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid response_type provided
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid response_type parameter
     When The user triggers an action with an invalid response_type parameter
     Then The result of an operation returns an error, because of an invalid response_type provided
 
-  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid client_id provided
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid client_id parameter
+  Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid client_id provided
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid client_id parameter
     When The user triggers an action with an invalid client_id parameter
     Then The result of an operation returns an error, because of an invalid client_id provided
 
-  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid redirect_uri provided
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid redirect_uri parameter
+  Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid redirect_uri provided
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid redirect_uri parameter
     When The user triggers an action with an invalid redirect_uri parameter
     Then The result of an operation returns an error, because of an invalid redirect_uri provided
 
-  Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because none parameters provided
-    Given The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint without parameters
+  Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint because none parameters provided
+    Given The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint without parameters
     When The user triggers an action without parameters
-    Then The result of an operation returns an error, because none parameters provided
+    Then The result of an operation returns an error because none parameters provided

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,0 +1,3 @@
+module.exports = {
+  localhost: "http://localhost:3344/",
+};

--- a/test/features/support/oidc_authorize.js
+++ b/test/features/support/oidc_authorize.js
@@ -32,15 +32,15 @@ Before(() => {
   specOIDCAuthorize = pactum.spec();
 });
 
-// Scenario: Successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
+// Scenario: Successfully loads the JS application and validates the provided query parameters using the OAuth-details endpoint
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint",
   () => {
     return "Every provided query parameters are valid";
   }
 );
 
-When("The user triggers an action with every required parameters", () => {
+When("The user triggers an action with every required parameter", () => {
   requestFunction(
     validScope,
     validResponseType,
@@ -50,16 +50,16 @@ When("The user triggers an action with every required parameters", () => {
 });
 
 Then(
-  "The user successfully loads JS application, and validates the provided query parameters using oauth-details endpoint",
+  "The user successfully loads the JS application and validates the provided query parameters using the OAuth-details endpoint",
   async () => {
     await specOIDCAuthorize.toss();
     specOIDCAuthorize.response().should.have.status(200);
   }
 );
 
-// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
+// Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid scope provided
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid scope parameter",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid scope parameter",
   () => {
     invalidScope = "Invalid Scope";
 
@@ -77,15 +77,15 @@ When("The user triggers an action with an invalid scope parameter", () =>
 );
 
 Then(
-  "The result of an operation returns an error, because of an invalid scope provided",
+  "The result of an operation returns an error because of an invalid scope provided",
   async () => {
     await errorResultFunction();
   }
 );
 
-// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
+// Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid scope provided
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid response_type parameter",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid response_type parameter",
   () => {
     invalidResponseType = "Not a code";
   }
@@ -109,9 +109,9 @@ Then(
   }
 );
 
-// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid client_id provided
+// Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid client_id provided
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid client_id parameter",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid client_id parameter",
   () => {
     invalidClientId = "";
     return invalidClientId;
@@ -133,9 +133,9 @@ Then(
     await errorResultFunction();
   }
 );
-// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid redirect_uri provided
+// Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint, because of an invalid redirect_uri provided
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid redirect_uri parameter",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint with an invalid redirect_uri parameter",
   () => {
     invalidRedirectUri = "";
     return invalidRedirectUri;
@@ -161,9 +161,9 @@ Then(
   }
 );
 
-// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because none parameters provided
+// Scenario: The user is not able to load the JS application and validates the provided query parameters using the OAuth-details endpoint because none parameters provided
 Given(
-  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint without parameters",
+  "The user wants to load the JS application and validates the provided query parameters using the OAuth-details endpoint without parameters",
   () => {
     return "None parameters provided";
   }
@@ -174,7 +174,7 @@ When("The user triggers an action without parameters", () =>
 );
 
 Then(
-  "The result of an operation returns an error, because none parameters provided",
+  "The result of an operation returns an error because none parameters provided",
   async () => {
     await errorResultFunction();
   }

--- a/test/features/support/oidc_authorize.js
+++ b/test/features/support/oidc_authorize.js
@@ -1,0 +1,185 @@
+const pactum = require("pactum");
+const { Given, When, Then, Before, After } = require("@cucumber/cucumber");
+const { localhost } = require("./helpers/helpers");
+
+let specOIDCAuthorize;
+let invalidScope;
+let invalidResponseType;
+let invalidClientId;
+let invalidRedirectUri;
+
+const baseUrl = `${localhost}authorize`;
+
+const validScope = "openid profile";
+const validResponseType = "code";
+const validClientId = "1245435";
+const validRedirect_uri = "http://example.com";
+
+const requestFunction = (scope, responseType, clientId, redirectUri) =>
+  specOIDCAuthorize
+    .get(baseUrl)
+    .withQueryParams("scope", scope)
+    .withQueryParams("response_type", responseType)
+    .withQueryParams("client_id", clientId)
+    .withQueryParams("redirect_uri", redirectUri);
+
+const errorResultFunction = async () => {
+  await specOIDCAuthorize.toss();
+  specOIDCAuthorize.response().should.have.status(400);
+};
+
+Before(() => {
+  specOIDCAuthorize = pactum.spec();
+});
+
+// Scenario: Successfully loads JS application, and validates the provided query parameters using oauth-details endpoint
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint",
+  () => {
+    return "Every provided query parameters are valid";
+  }
+);
+
+When("The user triggers an action with every required parameters", () => {
+  requestFunction(
+    validScope,
+    validResponseType,
+    validClientId,
+    validRedirect_uri
+  );
+});
+
+Then(
+  "The user successfully loads JS application, and validates the provided query parameters using oauth-details endpoint",
+  async () => {
+    await specOIDCAuthorize.toss();
+    specOIDCAuthorize.response().should.have.status(200);
+  }
+);
+
+// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid scope parameter",
+  () => {
+    invalidScope = "Invalid Scope";
+
+    return invalidScope;
+  }
+);
+
+When("The user triggers an action with an invalid scope parameter", () =>
+  requestFunction(
+    invalidScope,
+    validResponseType,
+    validClientId,
+    validRedirect_uri
+  )
+);
+
+Then(
+  "The result of an operation returns an error, because of an invalid scope provided",
+  async () => {
+    await errorResultFunction();
+  }
+);
+
+// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid scope provided
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid response_type parameter",
+  () => {
+    invalidResponseType = "Not a code";
+  }
+);
+
+When(
+  "The user triggers an action with an invalid response_type parameter",
+  () =>
+    requestFunction(
+      validScope,
+      invalidResponseType,
+      validClientId,
+      validRedirect_uri
+    )
+);
+
+Then(
+  "The result of an operation returns an error, because of an invalid response_type provided",
+  async () => {
+    await errorResultFunction();
+  }
+);
+
+// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid client_id provided
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid client_id parameter",
+  () => {
+    invalidClientId = "";
+    return invalidClientId;
+  }
+);
+
+When("The user triggers an action with an invalid client_id parameter", () =>
+  requestFunction(
+    validScope,
+    validResponseType,
+    invalidClientId,
+    validRedirect_uri
+  )
+);
+
+Then(
+  "The result of an operation returns an error, because of an invalid client_id provided",
+  async () => {
+    await errorResultFunction();
+  }
+);
+// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because of an invalid redirect_uri provided
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint with an invalid redirect_uri parameter",
+  () => {
+    invalidRedirectUri = "";
+    return invalidRedirectUri;
+  }
+);
+
+When(
+  "The user triggers an action with an invalid redirect_uri parameter",
+  () => {
+    requestFunction(
+      validScope,
+      validResponseType,
+      validClientId,
+      invalidRedirectUri
+    );
+  }
+);
+
+Then(
+  "The result of an operation returns an error, because of an invalid redirect_uri provided",
+  async () => {
+    await errorResultFunction();
+  }
+);
+
+// Scenario: The user is not able to load JS application, and validates the provided query parameters using the oauth-details endpoint, because none parameters provided
+Given(
+  "The user wants to loads JS application, and validates the provided query parameters using oauth-details endpoint without parameters",
+  () => {
+    return "None parameters provided";
+  }
+);
+
+When("The user triggers an action without parameters", () =>
+  specOIDCAuthorize.get(baseUrl)
+);
+
+Then(
+  "The result of an operation returns an error, because none parameters provided",
+  async () => {
+    await errorResultFunction();
+  }
+);
+
+After(() => {
+  specOIDCAuthorize.end();
+});


### PR DESCRIPTION
Create test configuration for "/authorize" endpoint.

Create test configuration for /authorize endpoint from https://github.com/GovStackWorkingGroup/bb-identity/pull/6 . Identify the critical APIs for Authentication, write the test plan and Cucumber tests, as well as supporting code to run those Cucumber tests.

TICKET: https://govstack-global.atlassian.net/browse/TECH-134