### PR TITLE
Tech-143-FIX: Create test configuration for "/authorization/auth-code" endpoint

### DIFF
--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -583,14 +583,14 @@
             {
               "target": "body",
               "modifier": "requestTime",
-              "value": "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z)$",
+              "value": "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d[\\.\\,]\\d+([+-][0-2]\\d:[0-5]\\d|Z)$",
               "invert": false,
               "operator": "regex"
             },
             {
               "target": "body",
               "modifier": "request.transactionId",
-              "value": "[a-zA-Z0-9_]",
+              "value": "^[a-zA-Z0-9_]+$",
               "invert": false,
               "operator": "regex"
             }
@@ -598,7 +598,7 @@
           "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
-          "default": true
+          "default": false
         },
         {
           "uuid": "d2089dce-3451-4dcc-85d6-d8acf8a85b2f",
@@ -615,7 +615,7 @@
             {
               "target": "body",
               "modifier": "request.transactionId",
-              "value": "[a-zA-Z0-9_]",
+              "value": "^[a-zA-Z0-9_]+$",
               "invert": true,
               "operator": "regex"
             }
@@ -630,7 +630,7 @@
           "body": "{\n\t\"responseTime\": \"string\",\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "Invalid request - invalid responseTime parameter.",
+          "label": "Invalid request",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -648,7 +648,7 @@
           "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
-          "default": false
+          "default": true
         }
       ],
       "enabled": true,

--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -377,13 +377,13 @@
       "responseMode": null
     },
     {
-      "uuid": "f90e90b4-866f-478f-b34c-a358d8196f01",
+      "uuid": "8c73a52f-1125-4508-a005-529e1d0d273a",
       "documentation": "API to add new open ID connect (OIDC) clients,",
       "method": "post",
       "endpoint": "client-mgmt/oidc-client",
       "responses": [
         {
-          "uuid": "bf45f01a-d052-430c-8a88-ea4524b29f69",
+          "uuid": "a1c98d60-5483-4d20-a2b8-15c42a6477f4",
           "body": "{\n  \"responseTime\": \"string\",\n  \"response\": {\n    \"clientId\": \"string\"\n  },\n  \"errors\": []\n}",
           "latency": 0,
           "statusCode": 200,
@@ -554,6 +554,98 @@
             }
           ],
           "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "21decdf3-79e0-453f-b9e5-fb5234fb6cd0",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "authorization/auth-code",
+      "responses": [
+        {
+          "uuid": "7b24fa35-f434-4bfe-b48c-e76d0e0a1d11",
+          "body": "{\n\t\"responseTime\": \"string\",\n\t\"response\": {\n\t\t\"code\": \"string\",\n\t\t\"redirectUri\": \"string\",\n\t\t\"nonce\": \"string\",\n\t\t\"state\": \"string\"\n\t}\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Successfully send the accepted consent and permitted scopes.",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "requestTime",
+              "value": "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z)$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "body",
+              "modifier": "request.transactionId",
+              "value": "[a-zA-Z0-9_]",
+              "invert": false,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        },
+        {
+          "uuid": "d2089dce-3451-4dcc-85d6-d8acf8a85b2f",
+          "body": "{\n\t\"responseTime\": \"string\",\n\t\"response\": null,\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Invalid request - invalid transactionId parameter.",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "request.transactionId",
+              "value": "[a-zA-Z0-9_]",
+              "invert": true,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        },
+        {
+          "uuid": "9c996a79-6cd1-4165-bc6c-19c18e3721af",
+          "body": "{\n\t\"responseTime\": \"string\",\n\t\"response\": null,\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Invalid request - invalid responseTime parameter.",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "requestTime",
+              "value": "^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z)$",
+              "invert": true,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
           "default": false

--- a/examples/mock/mockoon-bbidentity.json
+++ b/examples/mock/mockoon-bbidentity.json
@@ -602,9 +602,9 @@
         },
         {
           "uuid": "d2089dce-3451-4dcc-85d6-d8acf8a85b2f",
-          "body": "{\n\t\"responseTime\": \"string\",\n\t\"response\": null,\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
+          "body": "{\n\t\"responseTime\": \"string\",\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
           "latency": 0,
-          "statusCode": 400,
+          "statusCode": 200,
           "label": "Invalid request - invalid transactionId parameter.",
           "headers": [],
           "bodyType": "INLINE",
@@ -627,9 +627,9 @@
         },
         {
           "uuid": "9c996a79-6cd1-4165-bc6c-19c18e3721af",
-          "body": "{\n\t\"responseTime\": \"string\",\n\t\"response\": null,\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
+          "body": "{\n\t\"responseTime\": \"string\",\n\t\"errors\": [{\n      \"errorCode\": \"invalid_request\",\n      \"errorMessage\": \"string\"\n  }]\n}",
           "latency": 0,
-          "statusCode": 400,
+          "statusCode": 200,
           "label": "Invalid request - invalid responseTime parameter.",
           "headers": [],
           "bodyType": "INLINE",

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,5 +1,57 @@
 module.exports = {
-  localhost: "http://localhost:3344/",
-  validTransactionId: "jskSD23wes324545F",
-  requestTime: new Date().toISOString(),
+  localhost: 'http://localhost:3344/',
+  status_code_200: 200,
+  validTransactionId: 'jskSD23wes324545F',
+  request_time: new Date().toISOString(),
+  default_response_time: 15000,
+  ui_auth_code_endpoint: 'authorization/auth-code',
+  ui_auth_code_response_schema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string',
+      },
+      version: {
+        type: 'string',
+      },
+      responseTime: {
+        type: 'string',
+      },
+      response: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+          },
+          redirectUri: {
+            type: 'string',
+          },
+          nonce: {
+            type: 'string',
+          },
+          state: {
+            type: 'string',
+          },
+        },
+        additionalProperties: false,
+      },
+      errors: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            errorCode: {
+              type: 'string',
+              enum: ['invalid_request', 'invalid_transaction'],
+            },
+            errorMessage: {
+              type: 'string',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+    additionalProperties: false,
+  },
 };

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,11 +1,11 @@
 module.exports = {
   localhost: 'http://localhost:3344/',
-  status_code_200: 200,
+  statusCode200: 200,
   validTransactionId: 'jskSD23wes324545F',
-  request_time: new Date().toISOString(),
-  default_response_time: 15000,
-  ui_auth_code_endpoint: 'authorization/auth-code',
-  ui_auth_code_response_schema: {
+  requestTime: new Date().toISOString(),
+  defaultResponseTime: 15000,
+  uiAuthCodeEndpoint: 'authorization/auth-code',
+  uiAuthCodeResponseSchema: {
     type: 'object',
     properties: {
       id: {

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,3 +1,5 @@
 module.exports = {
   localhost: "http://localhost:3344/",
+  validTransactionId: "jskSD23wes324545F",
+  requestTime: new Date().toISOString(),
 };

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -1,0 +1,103 @@
+const pactum = require("pactum");
+const { Given, When, Then, Before, After } = require("@cucumber/cucumber");
+const {
+  localhost,
+  validTransactionId,
+  requestTime,
+} = require("./helpers/helpers");
+
+let specUIAuthCode;
+let invalidTransactionId;
+
+const baseUrl = `${localhost}authorization/auth-code`;
+
+const requestFunction = (transactionId) =>
+  specUIAuthCode.post(baseUrl).withBody({
+    requestTime: requestTime,
+    request: {
+      transactionId: transactionId,
+      permittedAuthorizeScopes: ["string"],
+      acceptedClaims: ["string"],
+    },
+  });
+
+const errorResultFunction = async () => {
+  await specUIAuthCode.toss();
+  specUIAuthCode.response().should.have.status(400);
+  specUIAuthCode.response().should.have.jsonLike({
+    responseTime: "string",
+    response: null,
+    errors: [
+      {
+        errorCode: "invalid_request",
+        errorMessage: "string",
+      },
+    ],
+  });
+};
+
+Before(() => {
+  specUIAuthCode = pactum.spec();
+});
+
+// Scenario: Successfully receive the authorization code
+Given(
+  "The end-user wants to receive the authorization code",
+  () => "Every required body parameters are valid"
+);
+
+When(
+  "The end-user triggers an action with the required parameters to receive the authorization code",
+  () => requestFunction(validTransactionId)
+);
+
+Then("The end-user successfully received the authorization code", async () => {
+  await specUIAuthCode.toss();
+  specUIAuthCode.toss();
+  specUIAuthCode.response().should.have.status(200);
+  specUIAuthCode.response().should.have.jsonLike({
+    responseTime: "string",
+    response: {
+      code: "string",
+      redirectUri: "string",
+      nonce: "string",
+      state: "string",
+    },
+  });
+});
+
+// Scenario: The user is not able to receive the authorization code because of an invalid transactionId parameter
+Given(
+  "The user wants to receive the authorization code with an invalid transactionId parameter",
+  () => (invalidTransactionId = "")
+);
+
+When(
+  "The user triggers an action with an invalid transactionId to receive the authorization code",
+  () => requestFunction(invalidTransactionId)
+);
+
+Then(
+  "The result of an operation to receive the authorization code because of an invalid transactionId provided",
+  async () => await errorResultFunction()
+);
+
+// Scenario: The user cannot get the authorization code because no parameter was specified
+Given(
+  "The user wants to obtain the authorization code without specifying a parameter",
+  () => "None of the required parameters was provided."
+);
+
+When(
+  "The user triggers an action without specifying a parameter to receive the authorization code",
+  () => specUIAuthCode.post(baseUrl).withBody()
+);
+
+Then(
+  "The result of an operation to receive the authorization code because no parameter was specified",
+  async () => await errorResultFunction()
+);
+
+After(() => {
+  specUIAuthCode.end();
+});

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -3,26 +3,26 @@ const { spec } = require('pactum');
 const { Given, When, Then, Before, After } = require('@cucumber/cucumber');
 const {
   localhost,
-  default_response_time,
-  ui_auth_code_endpoint,
-  ui_auth_code_response_schema,
-  status_code_200,
-  request_time,
+  defaultResponseTime,
+  uiAuthCodeEndpoint,
+  uiAuthCodeResponseSchema,
+  statusCode200,
+  requestTime,
 } = require('./helpers/helpers');
 
 chai.use(require('chai-json-schema'));
 
 let specUIAuthCode;
-const baseUrl = localhost + ui_auth_code_endpoint;
-const tag = { tags: `@endpoint=/${ui_auth_code_endpoint}` };
+const baseUrl = localhost + uiAuthCodeEndpoint;
+const tag = { tags: `@endpoint=/${uiAuthCodeEndpoint}` };
 
-const requestFunction = (transactionId, permitted_authorize_scopes, accepted_claims) =>
+const requestFunction = (transactionId, permittedAuthorizeScopes, acceptedClaims) =>
   specUIAuthCode.post(baseUrl).withBody({
-    requestTime: request_time,
+    requestTime: requestTime,
     request: {
       transactionId: transactionId,
-      permittedAuthorizeScopes: permitted_authorize_scopes,
-      acceptedClaims: accepted_claims,
+      permittedAuthorizeScopes: permittedAuthorizeScopes,
+      acceptedClaims: acceptedClaims,
     },
   });
 
@@ -38,11 +38,11 @@ Given(
 
 When(
   'POST request with given current date as requestTime {string} as transactionId {string} as permittedAuthorizeScopes {string} as acceptedClaims is sent',
-  (transactionId, permitted_authorize_scopes, accepted_claims) => {
-    const scopes = permitted_authorize_scopes.split(',').map((scope) => {
+  (transactionId, permittedAuthorizeScopes, acceptedClaims) => {
+    const scopes = permittedAuthorizeScopes.split(',').map((scope) => {
       return scope.trim();
     });
-    const claims = accepted_claims.split(',').map((claim) => {
+    const claims = acceptedClaims.split(',').map((claim) => {
       return claim.trim();
     });
     requestFunction(transactionId, scopes, claims);
@@ -52,11 +52,11 @@ When(
 Then('The response is received', async () => await specUIAuthCode.toss());
 
 Then('The response should be returned in a timely manner', () =>
-  specUIAuthCode.response().to.have.responseTimeLessThan(default_response_time)
+  specUIAuthCode.response().to.have.responseTimeLessThan(defaultResponseTime)
 );
 
 Then('The response should match json schema', () =>
-  chai.expect(specUIAuthCode._response.json).to.be.jsonSchema(ui_auth_code_response_schema)
+  chai.expect(specUIAuthCode._response.json).to.be.jsonSchema(uiAuthCodeResponseSchema)
 );
 
 Then('The response should contain authorization code', () => {
@@ -67,7 +67,7 @@ Then('The response should contain authorization code', () => {
 });
 
 Then('The response should have status 200', () =>
-  specUIAuthCode.response().to.have.status(status_code_200)
+  specUIAuthCode.response().to.have.status(statusCode200)
 );
 
 Then('The response header content-type should be {string}', (header_value) =>

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -78,7 +78,7 @@ const responseValidator = async (withErrors = false) => {
 
 Before(() => {
   specUIAuthCode = pactum.spec();
-  specUIAuthCode.expectResponseTime(1500);
+  specUIAuthCode.expectResponseTime(15000);
 });
 
 // Scenario: Successfully receive the authorization code

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -52,7 +52,7 @@ const requestFunction = (transactionId) =>
 
 const responseValidator = async (withErrors = false) => {
   if (!withErrors) {
-    responseSchema.properties.errors = { type: "array" };
+    responseSchema.properties.errors = { type: "array", maxItems: 0 };
   } else {
     responseSchema.properties.errors = {
       type: "array",
@@ -78,6 +78,7 @@ const responseValidator = async (withErrors = false) => {
 
 Before(() => {
   specUIAuthCode = pactum.spec();
+  specUIAuthCode.expectResponseTime(1500);
 });
 
 // Scenario: Successfully receive the authorization code

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -55,8 +55,12 @@ Then('The response should be returned in a timely manner', () =>
   specUIAuthCode.response().to.have.responseTimeLessThan(defaultResponseTime)
 );
 
-Then('The response should match json schema', () =>
-  chai.expect(specUIAuthCode._response.json).to.be.jsonSchema(uiAuthCodeResponseSchema)
+Then('The response should have status 200', () =>
+  specUIAuthCode.response().to.have.status(statusCode200)
+);
+
+Then('The response header content-type should be {string}', (header_value) =>
+  specUIAuthCode.response().to.have.header('content-type', header_value)
 );
 
 Then('The response should contain authorization code', () => {
@@ -66,12 +70,8 @@ Then('The response should contain authorization code', () => {
   chai.expect(specUIAuthCode._response.json.response.code).to.not.be.empty;
 });
 
-Then('The response should have status 200', () =>
-  specUIAuthCode.response().to.have.status(statusCode200)
-);
-
-Then('The response header content-type should be {string}', (header_value) =>
-  specUIAuthCode.response().to.have.header('content-type', header_value)
+Then('The response should match json schema', () =>
+  chai.expect(specUIAuthCode._response.json).to.be.jsonSchema(uiAuthCodeResponseSchema)
 );
 
 // Scenario: Unable to retrieve the authorization code because of an invalid transactionId parameter

--- a/test/features/support/ui_authorization_auth_code.js
+++ b/test/features/support/ui_authorization_auth_code.js
@@ -74,7 +74,7 @@ Then('The response should match json schema', () =>
   chai.expect(specUIAuthCode._response.json).to.be.jsonSchema(uiAuthCodeResponseSchema)
 );
 
-// Scenario: Unable to retrieve the authorization code because of an invalid transactionId parameter
+// Scenario Outline: Unable to retrieve the authorization code because of an invalid transactionId parameter
 // Code for this scenario is written in the aforementioned example
 
 // Scenario: Unable to retrieve the authorization code because no parameter was specified

--- a/test/features/ui_authorization_auth_code.feature
+++ b/test/features/ui_authorization_auth_code.feature
@@ -1,23 +1,47 @@
-Feature: The API sends the accepted consent and permitted scopes and receives the authorization code.
+@method=POST @endpoint=/authorization/auth-code
+Feature: The API sends the accepted consent and permitted scopes and retrieves the authorization code.
 
-  Once the authentication is successful and user consent is obtained,
-  this endpoint will be invoked by the UI application to send the accepted consent and permitted scopes.
-  The UI application will receive the authorization code and a few other details required for redirecting
-  to the client / relying party application. 
+  This endpoint is invoked from JS application to send the accepted consent and permitted scopes.
 
-  Request endpoint: POST /authorization/auth-code
+  @smoke @unit @positive
+  Scenario: Successfully retrieve the authorization code
 
-  Scenario: Successfully receive the authorization code
-    Given The end-user wants to receive the authorization code
-    When The end-user tries to trigger an action with the required parameters to receive the authorization code
-    Then The end-user successfully received the authorization code
+    Given The end-user wants to send the accepted consent and permitted scopes via JS application
+    When POST request with given current date as requestTime "jskSD23wes324545F" as transactionId "string" as permittedAuthorizeScopes "string" as acceptedClaims is sent
+    Then The response is received
+    And The response should be returned in a timely manner
+    And The response should match json schema
+    And The response should contain authorization code
+    And The response should have status 200
+    And The response header content-type should be "application/json; charset=utf-8"
 
-  Scenario: The user is not able to receive the authorization code because of an invalid transactionId parameter
-    Given The end-user wants to receive the authorization code with an invalid transactionId parameter
-    When The end-user tries to trigger an action with an invalid transactionId to receive the authorization code
-    Then The result of an operation to receive the authorization code because an invalid transactionId was specified
 
-  Scenario: The user cannot get the authorization code because no parameter was specified
-    Given The end-user wants to obtain the authorization code without specifying a parameter
-    When The end-user tries to trigger an action without specifying a parameter to receive the authorization code
-    Then The result of an operation to receive the authorization code because no parameter was specified
+  @unit @negative
+  Scenario: Unable to retrieve the authorization code because of an invalid transactionId parameter
+
+    Given The end-user wants to send the accepted consent and permitted scopes via JS application
+    When POST request with given current date as requestTime "<transactionId>" as transactionId "<permittedAuthorizeScopes>" as permittedAuthorizeScopes "<acceptedClaims>" as acceptedClaims is sent
+    Then The response is received
+    And The response should be returned in a timely manner
+    And The response should match json schema
+    And The response should have status 200
+    And The response header content-type should be "application/json; charset=utf-8"
+
+  Examples: Invalid transactionId
+  | transactionId | permittedAuthorizeScopes | acceptedClaims   |
+  | aaa-aaa-aaa   | string, string           | string           |
+  | invalid&id    | string, string           | string           |
+  | $id_invalid-x | string                   | string, string   |
+  |               | string                   | string           |
+
+
+  @unit @negative
+  Scenario: Unable to retrieve the authorization code because no parameter was specified
+
+    Given The end-user wants to send the accepted consent and permitted scopes via JS application
+    When POST request without payload is sent
+    Then The response is received
+    And The response should be returned in a timely manner
+    And The response should match json schema
+    And The response should have status 200
+    And The response header content-type should be "application/json; charset=utf-8"

--- a/test/features/ui_authorization_auth_code.feature
+++ b/test/features/ui_authorization_auth_code.feature
@@ -9,15 +9,15 @@ Feature: The API sends the accepted consent and permitted scopes and receives th
 
   Scenario: Successfully receive the authorization code
     Given The end-user wants to receive the authorization code
-    When The end-user triggers an action with the required parameters to receive the authorization code
+    When The end-user tries to trigger an action with the required parameters to receive the authorization code
     Then The end-user successfully received the authorization code
 
   Scenario: The user is not able to receive the authorization code because of an invalid transactionId parameter
-    Given The user wants to receive the authorization code with an invalid transactionId parameter
-    When The user triggers an action with an invalid transactionId to receive the authorization code
-    Then The result of an operation to receive the authorization code because of an invalid transactionId provided
+    Given The end-user wants to receive the authorization code with an invalid transactionId parameter
+    When The end-user tries to trigger an action with an invalid transactionId to receive the authorization code
+    Then The result of an operation to receive the authorization code because an invalid transactionId was specified
 
   Scenario: The user cannot get the authorization code because no parameter was specified
-    Given The user wants to obtain the authorization code without specifying a parameter
-    When The user triggers an action without specifying a parameter to receive the authorization code
+    Given The end-user wants to obtain the authorization code without specifying a parameter
+    When The end-user tries to trigger an action without specifying a parameter to receive the authorization code
     Then The result of an operation to receive the authorization code because no parameter was specified

--- a/test/features/ui_authorization_auth_code.feature
+++ b/test/features/ui_authorization_auth_code.feature
@@ -16,7 +16,7 @@ Feature: The API sends the accepted consent and permitted scopes and retrieves t
     And The response should match json schema
 
   @unit @negative
-  Scenario: Unable to retrieve the authorization code because of an invalid transactionId parameter
+  Scenario Outline: Unable to retrieve the authorization code because of an invalid transactionId parameter
 
     Given The end-user wants to send the accepted consent and permitted scopes via JS application
     When POST request with given current date as requestTime "<transactionId>" as transactionId "<permittedAuthorizeScopes>" as permittedAuthorizeScopes "<acceptedClaims>" as acceptedClaims is sent

--- a/test/features/ui_authorization_auth_code.feature
+++ b/test/features/ui_authorization_auth_code.feature
@@ -1,0 +1,23 @@
+Feature: The API sends the accepted consent and permitted scopes and receives the authorization code.
+
+  Once the authentication is successful and user consent is obtained,
+  this endpoint will be invoked by the UI application to send the accepted consent and permitted scopes.
+  The UI application will receive the authorization code and a few other details required for redirecting
+  to the client / relying party application. 
+
+  Request endpoint: POST /authorization/auth-code
+
+  Scenario: Successfully receive the authorization code
+    Given The end-user wants to receive the authorization code
+    When The end-user triggers an action with the required parameters to receive the authorization code
+    Then The end-user successfully received the authorization code
+
+  Scenario: The user is not able to receive the authorization code because of an invalid transactionId parameter
+    Given The user wants to receive the authorization code with an invalid transactionId parameter
+    When The user triggers an action with an invalid transactionId to receive the authorization code
+    Then The result of an operation to receive the authorization code because of an invalid transactionId provided
+
+  Scenario: The user cannot get the authorization code because no parameter was specified
+    Given The user wants to obtain the authorization code without specifying a parameter
+    When The user triggers an action without specifying a parameter to receive the authorization code
+    Then The result of an operation to receive the authorization code because no parameter was specified

--- a/test/features/ui_authorization_auth_code.feature
+++ b/test/features/ui_authorization_auth_code.feature
@@ -10,11 +10,10 @@ Feature: The API sends the accepted consent and permitted scopes and retrieves t
     When POST request with given current date as requestTime "jskSD23wes324545F" as transactionId "string" as permittedAuthorizeScopes "string" as acceptedClaims is sent
     Then The response is received
     And The response should be returned in a timely manner
-    And The response should match json schema
-    And The response should contain authorization code
     And The response should have status 200
     And The response header content-type should be "application/json; charset=utf-8"
-
+    And The response should contain authorization code
+    And The response should match json schema
 
   @unit @negative
   Scenario: Unable to retrieve the authorization code because of an invalid transactionId parameter
@@ -23,9 +22,9 @@ Feature: The API sends the accepted consent and permitted scopes and retrieves t
     When POST request with given current date as requestTime "<transactionId>" as transactionId "<permittedAuthorizeScopes>" as permittedAuthorizeScopes "<acceptedClaims>" as acceptedClaims is sent
     Then The response is received
     And The response should be returned in a timely manner
-    And The response should match json schema
     And The response should have status 200
     And The response header content-type should be "application/json; charset=utf-8"
+    And The response should match json schema
 
   Examples: Invalid transactionId
   | transactionId | permittedAuthorizeScopes | acceptedClaims   |
@@ -42,6 +41,6 @@ Feature: The API sends the accepted consent and permitted scopes and retrieves t
     When POST request without payload is sent
     Then The response is received
     And The response should be returned in a timely manner
-    And The response should match json schema
     And The response should have status 200
     And The response header content-type should be "application/json; charset=utf-8"
+    And The response should match json schema

--- a/test/package.json
+++ b/test/package.json
@@ -7,5 +7,10 @@
   "devDependencies": {
     "@cucumber/cucumber": "8.10.0",
     "pactum": "3.3.2"
+  },
+  "dependencies": {
+    "chai": "4.3.7",
+    "chai-json-schema": "1.5.1",
+    "prettier": "2.8.4"
   }
 }

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -199,6 +199,11 @@ assertion-error-formatter@^3.0.0:
     pad-right "^0.2.2"
     repeat-string "^1.6.1"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -236,6 +241,27 @@ centra@^2.6.0:
   resolved "https://registry.yarnpkg.com/centra/-/centra-2.6.0.tgz#79117998ee6908642258db263871381aa5d1204a"
   integrity sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ==
 
+chai-json-schema@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/chai-json-schema/-/chai-json-schema-1.5.1.tgz#d9ae4c8f8c6e24ff4d402ceddfaa865d1ca107f4"
+  integrity sha512-TR/xPDxRhqwFFCWg1HgL8nNWbpNfUwaib6pBN++QKpnd0t+o3+MBvAn5CM1mpdUMaM76oJAtUjGKdjGad01lIA==
+  dependencies:
+    jsonpointer.js "0.4.0"
+    tv4 "^1.3.0"
+
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -243,6 +269,11 @@ chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 class-transformer@0.5.1:
   version "0.5.1"
@@ -309,6 +340,13 @@ debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-override@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/deep-override/-/deep-override-1.0.2.tgz#82a98ff187a33d2e146a927450773a8aaac2c716"
@@ -371,6 +409,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 glob@^7.1.3, glob@^7.1.6:
   version "7.2.3"
@@ -454,6 +497,11 @@ json-query@^2.2.2:
   resolved "https://registry.yarnpkg.com/json-query/-/json-query-2.2.2.tgz#b6558b8a3794ccd217926aa38024324b77b48ab1"
   integrity sha512-y+IcVZSdqNmS4fO8t1uZF6RMMs0xh3SrTjJr9bp1X3+v0Q13+7Cyv12dSmKwDswp/H427BVtpkLWhGxYu3ZWRA==
 
+jsonpointer.js@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer.js/-/jsonpointer.js-0.4.0.tgz#002cb123f767aafdeb0196132ce5c4f9941ccaba"
+  integrity sha512-2bf/1crAmPpsmj1I6rDT6W0SOErkrNBpb555xNWcMVWYrX6VnXpG0GRMQ2shvOHwafpfse8q0gnzPFYVH6Tqdg==
+
 klona@^2.0.4, klona@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
@@ -490,6 +538,13 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -614,6 +669,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 phin@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/phin/-/phin-3.7.0.tgz#eeeff7660408515d8cf0c6252901012d4ab7153b"
@@ -628,6 +688,11 @@ polka@^0.5.2:
   dependencies:
     "@polka/url" "^0.5.0"
     trouter "^2.0.1"
+
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 progress@^2.0.3:
   version "2.0.3"
@@ -787,6 +852,16 @@ tslib@^2.0.3:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tv4@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
+  integrity sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 upper-case-first@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Added changes to auth-code endpoint based on gherkin file template: https://govstack-global.atlassian.net/wiki/spaces/GH/pages/157712385/Gherkin+file+template

**Description**: Create test configuration for /authorization/oauth-details endpoint from https://github.com/GovStackWorkingGroup/bb-identity/pull/6.
Identify the critical APIs for Authentication, write the test plan and Cucumber tests, as well as supporting code to run those Cucumber tests.

**Ticket**: https://govstack-global.atlassian.net/browse/TECH-143