### PR TITLE
TECH-863: fixes to gherkin and js tests

### DIFF
--- a/test/openAPI/features/client_create.feature
+++ b/test/openAPI/features/client_create.feature
@@ -8,7 +8,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema
     And The POST /client-mgmt/oidc-client endpoint response should contain "e-health-service" as clientId
     And The POST /client-mgmt/oidc-client endpoint response should contain empty errors array
@@ -20,7 +20,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema
     And The POST /client-mgmt/oidc-client endpoint response should contain "<clientId>" as clientId
     And The POST /client-mgmt/oidc-client endpoint response should contain empty errors array
@@ -39,7 +39,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_request"
 
@@ -50,7 +50,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_acr"
 
@@ -61,7 +61,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_claim"
 
@@ -72,7 +72,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_grant_type"
 
@@ -83,7 +83,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_client_auth"
 
@@ -94,7 +94,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_client_name"
 
@@ -105,7 +105,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_rp_id"
 
@@ -116,7 +116,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_uri"
 
@@ -127,7 +127,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_client_id"
 
@@ -138,7 +138,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_public_key"
 
@@ -149,7 +149,7 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "invalid_redirect_uri"
 
@@ -160,6 +160,6 @@ Feature: API to add new open ID connect (OIDC) clients.
     Then User receives a response from the POST /client-mgmt/oidc-client endpoint
     And The POST /client-mgmt/oidc-client endpoint response should be returned in a timely manner 15000ms
     And The POST /client-mgmt/oidc-client endpoint response should have status 200
-    And The POST /client-mgmt/oidc-client endpoint response should have content-type: application/json header
+    And The POST /client-mgmt/oidc-client response should have "content-type": "application/json" header
     And The POST /client-mgmt/oidc-client endpoint response should match json schema with error
     And The POST /client-mgmt/oidc-client endpoint response should match with error code "duplicate_client_id"

--- a/test/openAPI/features/client_update.feature
+++ b/test/openAPI/features/client_update.feature
@@ -9,7 +9,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should contain "e-health-service" as clientId
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should contain empty errors array
@@ -22,7 +22,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_client_auth"
 
@@ -34,7 +34,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_grant_type"
 
@@ -46,7 +46,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_claim"
 
@@ -58,7 +58,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_acr"
 
@@ -70,7 +70,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_redirect_uri"
 
@@ -82,7 +82,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_uri"
 
@@ -94,7 +94,7 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_client_name"
 
@@ -106,6 +106,6 @@ Feature: API to update existing Open ID Connect (OIDC) client.
     Then User receives a response from the PUT /client-mgmt/oidc-client/{client_id} endpoint
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should be returned in a timely manner 15000ms
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have status 200
-    And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should have content-type: application/json header
+    And The PUT /client-mgmt/oidc-client/{client_id} response should have "content-type": "application/json" header
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match json schema with error
     And The PUT /client-mgmt/oidc-client/{client_id} endpoint response should match with error code "invalid_client_id"

--- a/test/openAPI/features/oauth_token.feature
+++ b/test/openAPI/features/oauth_token.feature
@@ -4,24 +4,30 @@ Feature: API to create access token
   @smoke
   Scenario: The user successfully receives the id and access token smoke type test
     Given The user wants to receive the id token and access token
-    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "http://example.com" as redirectUri, "payment-service" as iss, "payment-service" as sub, "IDBB server" as aud, 1024 as exp, 1516239022 as iat
+    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "http://example.com" as redirectUri, "payment-service" as iss, "payment-service" as sub, "IDBB server" as aud, 1024 as exp, 1516239022 as iat, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 200
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json schema
     And The POST /oauth/token endpoint response should contain "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" as idToken
+    And The POST /oauth/token endpoint response should contain "string.string.string" as accessToken
+    And The POST /oauth/token endpoint response should contain "Bearer" as tokenType
+    And The POST /oauth/token endpoint response should contain 0 as expiresIn
 
   @unit @positive
   Scenario Outline: The user successfully receives the id and access token
     Given The user wants to receive the id token and access token
-    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "<clientId>" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "<redirectUri>" as redirectUri, "<clientId>" as iss, "<clientId>" as sub, "<audience>" as aud, 1024 as exp, 1516239022 as iat
+    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "<clientId>" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "<redirectUri>" as redirectUri, "<clientId>" as iss, "<clientId>" as sub, "<audience>" as aud, 1024 as exp, 1516239022 as iat, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 200
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json schema
     And The POST /oauth/token endpoint response should contain "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" as idToken
+    And The POST /oauth/token endpoint response should contain "string.string.string" as accessToken
+    And The POST /oauth/token endpoint response should contain "Bearer" as tokenType
+    And The POST /oauth/token endpoint response should contain 0 as expiresIn
 
     Examples: Valid data
       | clientId           | audience     | redirectUri            |
@@ -31,41 +37,41 @@ Feature: API to create access token
       | health-service     | IDBB server4 | http://redirectMe4.com |
 
   Scenario: The user is not able to receive the ID and access token because of the invalid client_assertion
-    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "http://example.com" as redirectUri
+    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "http://example.com" as redirectUri, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 400
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json error schema
     And The POST /oauth/token endpoint response should contain "invalid_assertion" as errorType
 
   Scenario: The user is not able to receive the ID and access token because of the invalid client_assertion_type
     Given The user wants to receive the id token and access token
-    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "http://example.com" as redirectUri
+    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "http://example.com" as redirectUri, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 400
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json error schema
     And The POST /oauth/token endpoint response should contain "invalid_assertion_type" as errorType
 
   Scenario: The user is not able to receive the ID and access token because of the invalid redirect_uri
     Given The user wants to receive the id token and access token
-    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion
+    When The User sends POST request with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 400
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json error schema
     And The POST /oauth/token endpoint response should contain "invalid_redirect_uri" as errorType
 
   Scenario: The user is not able to receive the ID and access token because of the invalid input
     Given The user wants to receive the id token and access token
-    When The User sends POST request with given "" as grantType, "" as code, "" as clientId, "" as clientAssertionType, "" as clientAssertion, "" as redirectUri
+    When The User sends POST request with given "" as grantType, "" as code, "" as clientId, "" as clientAssertionType, "" as clientAssertion, "" as redirectUri, "content-type": "application/x-www-form-urlencoded" header
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 400
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json error schema
     And The POST /oauth/token endpoint response should contain "invalid_input" as errorType
 
@@ -75,6 +81,6 @@ Feature: API to create access token
     Then User receives a response from the POST /oauth/token endpoint
     And The POST /oauth/token endpoint response should be returned in a timely manner 15000ms
     And The POST /oauth/token endpoint response should have status 400
-    And The POST /oauth/token endpoint response should have content-type: application/json header
+    And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json error schema
     And The POST /oauth/token endpoint response should contain "invalid_payload" as errorType

--- a/test/openAPI/features/oauth_token.feature
+++ b/test/openAPI/features/oauth_token.feature
@@ -11,7 +11,7 @@ Feature: API to create access token
     And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json schema
     And The POST /oauth/token endpoint response should contain "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" as idToken
-    And The POST /oauth/token endpoint response should contain "string.string.string" as accessToken
+    And The POST /oauth/token endpoint response should contain "access_token"
     And The POST /oauth/token endpoint response should contain "Bearer" as tokenType
     And The POST /oauth/token endpoint response should contain 0 as expiresIn
 
@@ -25,7 +25,7 @@ Feature: API to create access token
     And The POST /oauth/token response should have "content-type": "application/json" header
     And The POST /oauth/token endpoint response should match json schema
     And The POST /oauth/token endpoint response should contain "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" as idToken
-    And The POST /oauth/token endpoint response should contain "string.string.string" as accessToken
+    And The POST /oauth/token endpoint response should contain "access_token"
     And The POST /oauth/token endpoint response should contain "Bearer" as tokenType
     And The POST /oauth/token endpoint response should contain 0 as expiresIn
 

--- a/test/openAPI/features/oidc_userinfo.feature
+++ b/test/openAPI/features/oidc_userinfo.feature
@@ -1,7 +1,7 @@
 @method=GET @endpoint=/oidc/userinfo
 Feature: API to receive user information
 
-  @smoke
+  @smoke @positive @unit
   Scenario: The user successfully receives user information smoke type test
     Given The user wants to receive user information
     Given The id_token is generated before GET /oidc/userinfo with given "authorization_code" as grantType, "code" as code, "payment-service" as clientId, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" as clientAssertionType, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." as clientAssertion, "http://example.com" as redirectUri, "payment-service" as iss, "payment-service" as sub, "IDBB server" as aud, 1024 as exp, 1516239022 as iat
@@ -9,5 +9,5 @@ Feature: API to receive user information
     Then User receives a response from the GET /oidc/userinfo endpoint
     And The GET /oidc/userinfo endpoint response should be returned in a timely manner 15000ms
     And The GET /oidc/userinfo endpoint response should have status 200
-    And The GET /oidc/userinfo endpoint response should have content-type: application/jwt header
+    And The GET /oidc/userinfo response should have "content-type": "application/jwt" header
     And The GET /oidc/userinfo endpoint response should match json schema

--- a/test/openAPI/features/oidc_well_known_jwks.feature
+++ b/test/openAPI/features/oidc_well_known_jwks.feature
@@ -8,6 +8,6 @@ Feature: Endpoint to retrieve all the public keys of the IDBB server
     Then The response from /.well-known/jwks.json endpoint is received
     And The response from /.well-known/jwks.json should be returned in a timely manner 15000ms
     And The response from /.well-known/jwks.json should have status 200
-    And The response from /.well-known/jwks.json should have content-type: application/json header
+    And The response from /.well-known/jwks.json response should have "content-type": "application/json" header
     And The response from /.well-known/jwks.json should match json schema
     And The combination of kid and kty is distinct for each element in the returned array

--- a/test/openAPI/features/oidc_well_known_openid_configuration.feature
+++ b/test/openAPI/features/oidc_well_known_openid_configuration.feature
@@ -8,5 +8,5 @@ Feature: This endpoint is only used to facilitate the OIDC provider details in a
     Then The response from /.well-known/openid-configuration endpoint is received
     And The response from /.well-known/openid-configuration should be returned in a timely manner 15000ms
     And The response from /.well-known/openid-configuration should have status 200
-    And The response from /.well-known/openid-configuration should have content-type: application/json header
+    And The response from /.well-known/openid-configuration response should have "content-type": "application/json" header
     And The response from /.well-known/openid-configuration should match json schema

--- a/test/openAPI/features/support/client_create.js
+++ b/test/openAPI/features/support/client_create.js
@@ -88,11 +88,11 @@ Then(
 );
 
 Then(
-  'The POST \\/client-mgmt\\/oidc-client endpoint response should have content-type: application\\/json header',
-  () =>
+  'The POST \\/client-mgmt\\/oidc-client response should have {string}: {string} header',
+  (key, value) =>
     specClientCreate
       .response()
-      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+      .should.have.headerContains(key, value)
 );
 
 Then(

--- a/test/openAPI/features/support/client_update.js
+++ b/test/openAPI/features/support/client_update.js
@@ -103,11 +103,11 @@ Then(
 );
 
 Then(
-  'The PUT \\/client-mgmt\\/oidc-client\\/\\{client_id} endpoint response should have content-type: application\\/json header',
-  () =>
+  'The PUT \\/client-mgmt\\/oidc-client\\/\\{client_id} response should have {string}: {string} header',
+  (key, value) =>
     specClientUpdate
       .response()
-      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+      .should.have.headerContains(key, value)
 );
 
 Then(

--- a/test/openAPI/features/support/oauth_token.js
+++ b/test/openAPI/features/support/oauth_token.js
@@ -107,12 +107,14 @@ Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as idT
       .to.be.equal(idToken);
   });
 
-Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as accessToken$/,
-  (accessToken) => {
+Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)"$/,
+  (propertyName) => {
     chai
-      .expect(specOAuthToken._response.json.access_token)
-      .to.be.equal(accessToken);
+      .expect(specOAuthToken._response.json)
+      .to.have.property(propertyName);
   });
+
+    
 
 Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as tokenType$/,
   (tokenType) => {

--- a/test/openAPI/features/support/oauth_token.js
+++ b/test/openAPI/features/support/oauth_token.js
@@ -34,7 +34,7 @@ Given(/^The user wants to receive the id token and access token$/,
 );
 
 Given(
- /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri, "([^"]*)" as iss, "([^"]*)" as sub, "([^"]*)" as aud, (\d+) as exp, (\d+) as iat$/,
+  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri, "([^"]*)" as iss, "([^"]*)" as sub, "([^"]*)" as aud, (\d+) as exp, (\d+) as iat, "([^"]*)": "([^"]*)" header$/,
   (
     grantType,
     code,
@@ -47,27 +47,33 @@ Given(
     aud,
     exp,
     iat,
-   ) => {
-    specOAuthToken.post(baseUrl).withJson({
-      grant_type: grantType,
-      client_assertion_type: clientAssertionType,
-      client_assertion:
-        clientAssertion +
-        jsonToBase64({
-          iss: iss,
-          sub: sub,
-          aud: aud,
-          exp: exp,
-          iat: iat,
-        }),
-      client_id: clientId,
-      code: code,
-      redirect_uri: redirectUri,
-     })
-});
+    contentTypeKey,
+    contentTypeValue,
+  ) => {
+    specOAuthToken.post(baseUrl)
+      .withHeaders({
+        contentTypeKey: contentTypeValue
+      })
+      .withForm({
+        grant_type: grantType,
+        client_assertion_type: clientAssertionType,
+        client_assertion:
+          clientAssertion +
+          jsonToBase64({
+            iss: iss,
+            sub: sub,
+            aud: aud,
+            exp: exp,
+            iat: iat,
+          }),
+        client_id: clientId,
+        code: code,
+        redirect_uri: redirectUri,
+      })
+  });
 
 Then(/^User receives a response from the POST \/oauth\/token endpoint$/,
- async () => await specOAuthToken.toss()
+  async () => await specOAuthToken.toss()
 );
 
 Then(/^The POST \/oauth\/token endpoint response should be returned in a timely manner 15000ms$/,
@@ -78,18 +84,18 @@ Then(/^The POST \/oauth\/token endpoint response should be returned in a timely 
   });
 
 Then(/^The POST \/oauth\/token endpoint response should have status (\d+)$/,
-    (status) => specOAuthToken.response().to.have.status(status)
+  (status) => specOAuthToken.response().to.have.status(status)
 );
 
-Then(/^The POST \/oauth\/token endpoint response should have content\-type: application\/json header$/,
-  () =>
+Then(/^The POST \/oauth\/token response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) =>
     specOAuthToken
       .response()
-      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+      .should.have.headerContains(key, value)
 );
 
 Then(/^The POST \/oauth\/token endpoint response should match json schema$/,
-  () =>  chai
+  () => chai
     .expect(specOAuthToken._response.json)
     .to.be.jsonSchema(oauthTokenResponse)
 );
@@ -99,33 +105,61 @@ Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as idT
     chai
       .expect(specOAuthToken._response.json.id_token)
       .to.be.equal(idToken);
-});
+  });
+
+Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as accessToken$/,
+  (accessToken) => {
+    chai
+      .expect(specOAuthToken._response.json.access_token)
+      .to.be.equal(accessToken);
+  });
+
+Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as tokenType$/,
+  (tokenType) => {
+    chai
+      .expect(specOAuthToken._response.json.token_type)
+      .to.be.equal(tokenType);
+  });
+
+Then(/^The POST \/oauth\/token endpoint response should contain (\d+) as expiresIn$/,
+  (expiresIn) => {
+    chai
+      .expect(specOAuthToken._response.json.expires_in)
+      .to.be.equal(expiresIn);
+  });
 
 // Scenario: The user is not able to receive the ID and access token because of the invalid client_assertion
 // Given for this scenario are written in the aforementioned example
 When(
-  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as redirectUri$/,
+  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as redirectUri, "([^"]*)": "([^"]*)" header$/,
   (
     grantType,
     code,
     clientId,
     clientAssertionType,
     redirectUri,
+    contentTypeKey,
+    contentTypeValue,
   ) => {
-    specOAuthToken.post(baseUrl).withJson({
-      grant_type: grantType,
-      client_assertion_type: clientAssertionType,
-      client_assertion: null,
-      client_id: clientId,
-      code: code,
-      redirect_uri: redirectUri,
-    })
-});
+    specOAuthToken.post(baseUrl)
+      .withHeaders({
+        contentTypeKey: contentTypeValue
+      })
+      .withForm({
+        grant_type: grantType,
+        client_assertion_type: clientAssertionType,
+        client_id: clientId,
+        code: code,
+        redirect_uri: redirectUri,
+      })
+  });
 
 Then(/^The POST \/oauth\/token endpoint response should match json error schema$/,
-    () =>  chai
-        .expect(specOAuthToken._response.json)
-        .to.be.jsonSchema(oauthTokenErrorResponse)
+  () => {
+    chai
+      .expect(specOAuthToken._response.json)
+      .to.be.jsonSchema(oauthTokenErrorResponse)
+  }
 );
 
 Then(
@@ -139,68 +173,84 @@ Then(
 // Scenario: The user is not able to receive the ID and access token because of the invalid client_assertion_type
 // Given, Then for this scenario are written in the aforementioned example
 When(
-  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri$/,
+  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri, "([^"]*)": "([^"]*)" header$/,
   (
     grantType,
     code,
     clientId,
     clientAssertion,
     redirectUri,
+    contentTypeKey,
+    contentTypeValue,
   ) => {
-    specOAuthToken.post(baseUrl).withJson({
-      grant_type: grantType,
-      client_assertion_type: null,
-      client_assertion: clientAssertion,
-      client_id: clientId,
-      code: code,
-      redirect_uri: redirectUri,
-    })
-});
+    specOAuthToken.post(baseUrl)
+      .withHeaders({
+        contentTypeKey: contentTypeValue
+      })
+      .withForm({
+        grant_type: grantType,
+        client_assertion: clientAssertion,
+        client_id: clientId,
+        code: code,
+        redirect_uri: redirectUri,
+      })
+  });
 
 
 // Scenario: The user is not able to receive the ID and access token because of the invalid redirect_uri
 // Given, Then for this scenario are written in the aforementioned example
 When(
-  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion$/,
+  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion, "([^"]*)": "([^"]*)" header$/,
   (
     grantType,
     code,
     clientId,
     clientAssertion,
     clientAssertionType,
+    contentTypeKey,
+    contentTypeValue,
   ) => {
-    specOAuthToken.post(baseUrl).withJson({
-      grant_type: grantType,
-      client_assertion_type: clientAssertionType,
-      client_assertion: clientAssertion,
-      client_id: clientId,
-      code: code,
-      redirect_uri: null,
-    })
-});
+    specOAuthToken.post(baseUrl)
+      .withHeaders({
+        contentTypeKey: contentTypeValue
+      })
+      .withForm({
+        grant_type: grantType,
+        client_assertion_type: clientAssertionType,
+        client_assertion: clientAssertion,
+        client_id: clientId,
+        code: code,
+      })
+  });
 
 
 // Scenario: The user is not able to receive the ID and access token because of the invalid input
 // Given, Then for this scenario are written in the aforementioned example
 When(
-  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri$/,
+  /^The User sends POST request with given "([^"]*)" as grantType, "([^"]*)" as code, "([^"]*)" as clientId, "([^"]*)" as clientAssertionType, "([^"]*)" as clientAssertion, "([^"]*)" as redirectUri, "([^"]*)": "([^"]*)" header$/,
   (
     grantType,
     code,
     clientId,
     clientAssertion,
     clientAssertionType,
-    redirectUri
-      ) => {
-    specOAuthToken.post(baseUrl).withJson({
-      grant_type: grantType,
-      client_assertion_type: clientAssertionType,
-      client_assertion: clientAssertion,
-      client_id: clientId,
-      code: code,
-      redirect_uri: redirectUri,
-    })
-});
+    redirectUri,
+    contentTypeKey,
+    contentTypeValue,
+  ) => {
+    specOAuthToken.post(baseUrl)
+      .withHeaders({
+        contentTypeKey: contentTypeValue
+      })
+      .withForm({
+        grant_type: grantType,
+        client_assertion_type: clientAssertionType,
+        client_assertion: clientAssertion,
+        client_id: clientId,
+        code: code,
+        redirect_uri: redirectUri,
+      })
+  });
 
 
 // Scenario: The user is not able to receive the ID and access token because of the empty payload
@@ -209,7 +259,7 @@ When(
   /^The User sends POST request without a payload$/,
   () => {
     specOAuthToken.post(baseUrl)
-});
+  });
 
 After(endpointTag, () => {
   specOAuthToken.end();

--- a/test/openAPI/features/support/oauth_token.js
+++ b/test/openAPI/features/support/oauth_token.js
@@ -114,8 +114,6 @@ Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)"$/,
       .to.have.property(propertyName);
   });
 
-    
-
 Then(/^The POST \/oauth\/token endpoint response should contain "([^"]*)" as tokenType$/,
   (tokenType) => {
     chai

--- a/test/openAPI/features/support/oidc_userinfo.js
+++ b/test/openAPI/features/support/oidc_userinfo.js
@@ -87,11 +87,11 @@ Then(/^The GET \/oidc\/userinfo endpoint response should have status (\d+)$/,
     (status) => specOidcUserinfo.response().to.have.status(status)
 );
 
-Then(/^The GET \/oidc\/userinfo endpoint response should have content\-type: application\/jwt header$/,
-    () =>
-        specOidcUserinfo
-            .response()
-            .should.have.header(contentTypeHeaderJWT.key, contentTypeHeaderJWT.value)
+Then(/^The GET \/oidc\/userinfo response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) =>
+      specOidcUserinfo
+      .response()
+      .should.have.headerContains(key, value)
 );
 
 Then(/^The GET \/oidc\/userinfo endpoint response should match json schema$/,

--- a/test/openAPI/features/support/oidc_well_known_jwks.js
+++ b/test/openAPI/features/support/oidc_well_known_jwks.js
@@ -33,8 +33,11 @@ Then(/^The response from \/\.well\-known\/jwks\.json should have status (\d+)$/,
   specJWKS.response().to.have.status(status)
 );
 
-Then(/^The response from \/\.well\-known\/jwks\.json should have content\-type: application\/json header$/, () =>
-  specJWKS.response().to.have.header(contentTypeHeader.key, contentTypeHeader.value)
+Then(/^The response from \/\.well\-known\/jwks\.json response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) =>
+    specJWKS
+      .response()
+      .should.have.headerContains(key, value)
 );
 
 Then(/^The response from \/\.well\-known\/jwks\.json should match json schema$/, () =>

--- a/test/openAPI/features/support/oidc_well_known_openid_configuration.js
+++ b/test/openAPI/features/support/oidc_well_known_openid_configuration.js
@@ -40,8 +40,11 @@ Then(/^The response from \/\.well\-known\/openid\-configuration should have stat
 );
 
 Then(
-  /^The response from \/\.well\-known\/openid\-configuration should have content\-type: application\/json header$/,
-  () => specOpenidConfiguration.response().to.have.header(contentTypeHeader.key, contentTypeHeader.value)
+  /^The response from \/\.well\-known\/openid\-configuration response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) =>
+    specOpenidConfiguration
+      .response()
+      .should.have.headerContains(key, value)
 );
 
 Then(/^The response from \/\.well\-known\/openid\-configuration should match json schema$/, () =>

--- a/test/openAPI/features/support/wallet_binding.js
+++ b/test/openAPI/features/support/wallet_binding.js
@@ -48,7 +48,7 @@ Given('Wants to validate the wallet and generate wallet user id',
     () => 'Wants to validate the wallet and generate wallet user id');
 
 When(
-    /^Send POST \/wallet\-binding request with given "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and publicKey$/,
+    /^Send POST \/wallet\-binding request with given "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and requestTime and publicKey$/,
     (individualId, authFactorType, format, challenge) => {
       specWalletBinding
           .post(baseUrl)
@@ -91,11 +91,11 @@ Then(
 );
 
 Then(
-    /^The \/wallet\-binding endpoint endpoint response should have content\-type: application\/json header$/,
-    () =>
+    /^The \/wallet\-binding response should have "([^"]*)": "([^"]*)" header$/,
+    (key, value) =>
         specWalletBinding
-            .response()
-            .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+        .response()
+        .should.have.headerContains(key, value)
 );
 
 Then(
@@ -127,7 +127,7 @@ Then(
 // Scenario: Not able to generate the wallet binding because of unsupported challenge format
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-    /^Send POST \/wallet\-binding request with given invalid format "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and publicKey$/,
+    /^Send POST \/wallet\-binding request with given invalid format "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and requestTime and publicKey$/,
     (individualId, authFactorType, format, challenge) =>
         specWalletBinding
             .post(baseUrl)
@@ -174,7 +174,7 @@ Then(
 // Scenario: Not able to generate the wallet binding because of unsupported challenge format
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-  /^Send POST \/wallet\-binding request with given format "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and invalid publicKey$/,
+  /^Send POST \/wallet\-binding request with given format "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and requestTime and invalid publicKey$/,
   (individualId, authFactorType, format, challenge) =>
     specWalletBinding
       .post(baseUrl)
@@ -199,7 +199,7 @@ When(
 // Scenario: Not able to generate the wallet binding because of duplicated public key
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-  /^Send POST \/wallet\-binding request with given "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and duplicated publicKey$/,
+  /^Send POST \/wallet\-binding request with given "([^"]*)" as individualId and "([^"]*)" as authFactorType and "([^"]*)" as format and "([^"]*)" as challenge and requestTime and duplicated publicKey$/,
   (individualId, authFactorType, format, challenge) => {
     specWalletBinding
         .post(baseUrl)

--- a/test/openAPI/features/support/wallet_consent.js
+++ b/test/openAPI/features/support/wallet_consent.js
@@ -132,11 +132,11 @@ When(
 );
 
 Then(
-  'The \\/linked-authorization\\/consent endpoint response should have content-type: application\\/json header',
-  () =>
+  'The \\/linked-authorization\\/consent response should have {string}: {string} header',
+  (key, value) =>
     specWalletConsent
       .response()
-      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+      .should.have.headerContains(key, value)
 );
 
 Then(

--- a/test/openAPI/features/support/wallet_generate_link_auth_code.js
+++ b/test/openAPI/features/support/wallet_generate_link_auth_code.js
@@ -119,10 +119,10 @@ Given(
 );
 
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkCode and transactionId$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkedCode and transactionId and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-          .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+          .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
           .withJson({
           requestTime: new Date().toISOString(),
           request: {
@@ -151,11 +151,11 @@ Then(
 );
 
 Then(
-    /^The \/linked\-authorization\/link\-auth\-code endpoint response should have content\-type: application\/json header$/,
-    () =>
+    /^The \/linked\-authorization\/link\-auth\-code response should have "([^"]*)": "([^"]*)" header$/,
+    (key, value) =>
         specWalletGenerateLinkAuthCode
-            .response()
-            .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+        .response()
+        .should.have.headerContains(key, value)
 );
 
 Then(
@@ -168,13 +168,13 @@ Then(
     }
 );
 
-// Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkCode
+// Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkedCode
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid linkCode$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid linkedCode and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-          .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+          .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
           .withJson({
           requestTime: new Date().toISOString(),
           request: {
@@ -209,10 +209,10 @@ Then(
 // Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid transactionId
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid transactionId$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid transactionId and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-            .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+            .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
             .withJson({
               requestTime: new Date().toISOString(),
               request: {
@@ -222,13 +222,13 @@ When(
             })
 );
 
-// Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkCode and transactionId
+// Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkedCode and transactionId
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid linkCode and transactionId$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given invalid linkedCode and transactionId and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-            .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+            .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
             .withJson({
               requestTime: new Date().toISOString(),
               request: {
@@ -241,10 +241,10 @@ When(
 // Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid requestTime
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkCode and transactionId and invalidRequestTime$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkedCode and transactionId and "([^"]*)" header and invalid requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-            .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+            .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
             .withJson({
               requestTime: null,
               request: {
@@ -315,10 +315,10 @@ Given(/^The second link code, transaction and authenticate is completed before P
 })
 
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given valid linkCode and transactionId$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given valid linkedCode and transactionId and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCode.post(baseUrl)
-            .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+            .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
             .withJson({
               requestTime: new Date().toISOString(),
               request: {
@@ -402,10 +402,10 @@ Given(
 );
 
 When(
-    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkCode and reused completed transactionId$/,
-    () =>
+    /^Send POST \/linked\-authorization\/link\-auth\-code request with given linkedCode and reused completed transactionId and "([^"]*)" header and requestTime$/,
+    (X_XSRF_TOKEN) =>
         specWalletGenerateLinkAuthCodeReusable.post(baseUrl)
-            .withHeaders(X_XSRF_TOKEN.key, X_XSRF_TOKEN.value)
+            .withHeaders(X_XSRF_TOKEN, X_XSRF_TOKEN)
             .withJson({
               requestTime: new Date().toISOString(),
               request: {
@@ -434,11 +434,11 @@ Then(
 );
 
 Then(
-    /^The \/linked\-authorization\/link\-auth\-code endpoint response for reuse transactionId should have content\-type: application\/json header$/,
-    () =>
+    /^The \/linked\-authorization\/link\-auth\-code endpoint response for reuse transactionId should have "([^"]*)": "([^"]*)" header$/,
+    (key, value) =>
         specWalletGenerateLinkAuthCodeReusable
-            .response()
-            .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+        .response()
+        .should.have.headerContains(key, value)
 );
 
 Then(

--- a/test/openAPI/features/support/wallet_generate_link_code.js
+++ b/test/openAPI/features/support/wallet_generate_link_code.js
@@ -72,9 +72,11 @@ Then(/^The \/linked-authorization\/link-code endpoint response should have statu
 });
 
 Then(
-  /^The \/linked-authorization\/link-code endpoint response should have content-type: application\/json header$/,
-  () => {
-    specWalletGenerateLinkCode.response().should.have.header(contentTypeHeader.key, contentTypeHeader.value);
+  /^The \/linked-authorization\/link-code response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) => {
+    specWalletGenerateLinkCode
+      .response()
+      .should.have.headerContains(key, value)
   }
 );
 
@@ -202,7 +204,7 @@ Given(/^The first authorization flow for transactionId ends$/, async () => {
 });
 
 When(
-  /^Send POST \/linked-authorization\/link-code request with given X-XSRF-TOKEN header, XSRF-TOKEN cookie, reaused completed transactionId and requestTime$/,
+  /^Send POST \/linked-authorization\/link-code request with given X-XSRF-TOKEN header, XSRF-TOKEN cookie, already used completed transactionId and requestTime$/,
   () => {
     specWalletGenerateLinkCodeReused
       .post(baseUrl)
@@ -232,9 +234,11 @@ Then(
 );
 
 Then(
-  /^The \/linked-authorization\/link-code endpoint response for completed transactionId should have content-type: application\/json header$/,
-  () => {
-    specWalletGenerateLinkCodeReused.response().should.have.header(contentTypeHeader.key, contentTypeHeader.value);
+  /^The \/linked-authorization\/link-code endpoint response for completed transactionId should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) => {
+    specWalletGenerateLinkCodeReused
+    .response()
+    .should.have.headerContains(key, value);
   }
 );
 

--- a/test/openAPI/features/support/wallet_link_status.js
+++ b/test/openAPI/features/support/wallet_link_status.js
@@ -278,7 +278,7 @@ When(
   }
 );
 
-// Scenario: Not able to check the status of link code because of the link code connected to a different transaction id
+// Scenario: Not able to check the status of link code because of the linkCode connected to a different transactionId
 // Given and others Then for this scenario are written in the aforementioned example
 Given('The second link code for diffrent transaction id is generated', async () => {
   specWalletGenerateLinkCode_02
@@ -297,7 +297,7 @@ Given('The second link code for diffrent transaction id is generated', async () 
 });
 
 When(
-  /^Send POST \/linked-authorization\/link-status request with given X-XSRF-TOKEN header, transactionId, link code connected to a different transaction id and requestTime$/,
+  /^Send POST \/linked-authorization\/link-status request with given X-XSRF-TOKEN header, transactionId, linkCode connected to a different transactionId and requestTime$/,
   () => {
     specWalletLinkStatus
       .post(baseUrl)

--- a/test/openAPI/features/support/wallet_link_transaction.js
+++ b/test/openAPI/features/support/wallet_link_transaction.js
@@ -27,11 +27,11 @@ Before(endpointTag, () => {
   specWalletLinkTransaction = spec();
 });
 
-// Scenario: Successfully validates the link-code and its expiry and generates the linkTransactionId smoke type test
+// Scenario: Successfully validates the linkCode and its expiry and generates the linkTransactionId smoke type test
 Given(
-  'Wants to validate the link-code and its expiry and generate the linkTransactionId',
+  'Wants to validate the linkCode and its expiry and generate the linkTransactionId',
   () =>
-    'Wants to validate the link-code and its expiry and generate the linkTransactionId'
+    'Wants to validate the linkCode and its expiry and generate the linkTransactionId'
 );
 
 Given(
@@ -53,7 +53,7 @@ Given(
 );
 
 When(
-  'Send POST \\/linked-authorization\\/link-transaction request with given linkCode',
+  'Send POST \\/linked-authorization\\/link-transaction request with given linkCode and requestTime',
   () =>
     specWalletLinkTransaction.post(baseUrl).withJson({
       requestTime: new Date().toISOString(),
@@ -82,11 +82,11 @@ Then(
 );
 
 Then(
-  'The \\/linked-authorization\\/link-transaction endpoint response should have content-type: application\\/json header',
-  () =>
+  'The \\/linked-authorization\\/link-transaction response should have {string}: {string} header',
+  (key, value) =>
     specWalletLinkTransaction
       .response()
-      .should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+      .should.have.headerContains(key, value)
 );
 
 Then(
@@ -99,10 +99,10 @@ Then(
   }
 );
 
-// Scenario: Not able to validate the link-code and its expiry and generate the linkTransactionId because of invalid linkCode
+// Scenario: Not able to validate the linkCode and its expiry and generate the linkTransactionId because of invalid linkCode
 // Given and others Then for this scenario are written in the aforementioned example
 When(
-  'Send POST \\/linked-authorization\\/link-transaction request with given invalid linkCode',
+  'Send POST \\/linked-authorization\\/link-transaction request with given invalid linkCode and requestTime',
   () =>
     specWalletLinkTransaction.post(baseUrl).withJson({
       requestTime: new Date().toISOString(),
@@ -132,7 +132,7 @@ Then(
       .to.be.equal(errorCode)
 );
 
-// Scenario: Not able to validate the link-code and its expiry and generate the linkTransactionId because of expired linkCode
+// Scenario: Not able to validate the linkCode and its expiry and generate the linkTransactionId because of expired linkCode
 Given(
   'The link code is generated before POST \\/linked-authorization\\/link-transaction but wait 30s to be expired',
   { timeout: 31 * 1000 },
@@ -156,7 +156,7 @@ Given(
 );
 
 When(
-  'Send POST \\/linked-authorization\\/link-transaction request with given expired linkCode',
+  'Send POST \\/linked-authorization\\/link-transaction request with given expired linkCode and requestTime',
   () =>
     specWalletLinkTransaction.post(baseUrl).withJson({
       requestTime: new Date().toISOString(),

--- a/test/openAPI/features/support/wallet_linked_authenticate.js
+++ b/test/openAPI/features/support/wallet_linked_authenticate.js
@@ -93,8 +93,11 @@ Then('The \\/linked-authorization\\/authenticate endpoint response should have s
 );
 
 Then(
-  'The \\/linked-authorization\\/authenticate endpoint response should have content-type: application\\/json header',
-  () => specWalletLinkedAuthenticate.response().should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+  'The \\/linked-authorization\\/authenticate response should have {string}: {string} header',
+  (key, value) =>
+    specWalletLinkedAuthenticate
+      .response()
+      .should.have.headerContains(key, value)
 );
 
 Then(
@@ -208,8 +211,11 @@ Then('The \\/linked-authorization\\/authenticate endpoint response for reused li
 );
 
 Then(
-  'The \\/linked-authorization\\/authenticate endpoint response for reused link code should have content-type: application\\/json header',
-  () => specWalletLinkedAuthenticateReused.response().should.have.header(contentTypeHeader.key, contentTypeHeader.value)
+  'The \\/linked-authorization\\/authenticate endpoint response for reused link code should have {string}: {string} header',
+  (key, value) => 
+  specWalletLinkedAuthenticateReused
+  .response()
+  .should.have.headerContains(key, value)
 );
 
 Then(

--- a/test/openAPI/features/wallet_binding.feature
+++ b/test/openAPI/features/wallet_binding.feature
@@ -4,11 +4,11 @@ Feature: The endpoint to validate wallet create wallet user id
   @smoke @unit @positive
   Scenario: Successfully validates the wallet and generates the wallet user id smoke type test
     Given Wants to validate the wallet and generate wallet user id
-    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and publicKey
+    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and requestTime and publicKey
     Then Receive a response from the /wallet-binding endpoint
     And The /wallet-binding response should be returned in a timely manner 15000ms
     And The /wallet-binding endpoint response should have status 200
-    And The /wallet-binding endpoint endpoint response should have content-type: application/json header
+    And The /wallet-binding response should have "content-type": "application/json" header
     And The /wallet-binding endpoint response should match json schema with no errors
     And The /wallet-binding endpoint response should have authFactorType value should be equal to specified enum
     And The /wallet-binding endpoint response should contain a future expireDateTime in ISO 8601 format
@@ -16,45 +16,45 @@ Feature: The endpoint to validate wallet create wallet user id
   @negative
   Scenario: Not able to generate the wallet binding because of unsupported challenge format
     Given Wants to validate the wallet and generate wallet user id
-    When Send POST /wallet-binding request with given invalid format "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "invalid_format" as format and "string" as challenge and publicKey
+    When Send POST /wallet-binding request with given invalid format "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "invalid_format" as format and "string" as challenge and requestTime and publicKey
     Then Receive a response from the /wallet-binding endpoint
     And The /wallet-binding response should be returned in a timely manner 15000ms
     And The /wallet-binding endpoint response should have status 200
-    And The /wallet-binding endpoint endpoint response should have content-type: application/json header
+    And The /wallet-binding response should have "content-type": "application/json" header
     And The /wallet-binding endpoint response should match json schema with errors
     And The /wallet-binding response should contain errorCode property equals to "unsupported_challenge_format"
 
   @negative
   Scenario: Not able to generate the wallet binding because of invalid public key
     Given Wants to validate the wallet and generate wallet user id
-    When Send POST /wallet-binding request with given format "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and invalid publicKey
+    When Send POST /wallet-binding request with given format "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and requestTime and invalid publicKey
     Then Receive a response from the /wallet-binding endpoint
     And The /wallet-binding response should be returned in a timely manner 15000ms
     And The /wallet-binding endpoint response should have status 200
-    And The /wallet-binding endpoint endpoint response should have content-type: application/json header
+    And The /wallet-binding response should have "content-type": "application/json" header
     And The /wallet-binding endpoint response should match json schema with errors
     And The /wallet-binding response should contain errorCode property equals to "invalid_public_key"
 
   @negative
   Scenario: Not able to generate the wallet binding because of duplicated public key
     Given Wants to validate the wallet and generate wallet user id
-    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and duplicated publicKey
+    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "string" as challenge and requestTime and duplicated publicKey
     Then Receive a response from the /wallet-binding endpoint
     When Send POST /wallet-binding request with the same public key as in the previous request
     Then Receive a response from the /wallet-binding endpoint
     And The /wallet-binding response should be returned in a timely manner 15000ms
     And The /wallet-binding endpoint response should have status 200
-    And The /wallet-binding endpoint endpoint response should have content-type: application/json header
+    And The /wallet-binding response should have "content-type": "application/json" header
     And The /wallet-binding endpoint response should match json schema with errors
     And The /wallet-binding response should contain errorCode property equals to "duplicate_public_key"
 
   @negative
   Scenario: Not able to generate the wallet binding because of invalid auth challenge
     Given Wants to validate the wallet and generate wallet user id
-    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "" as challenge and publicKey
+    When Send POST /wallet-binding request with given "n3fy2qkg9r7h2" as individualId and "OTP" as authFactorType and "encoded-json" as format and "" as challenge and requestTime and publicKey
     Then Receive a response from the /wallet-binding endpoint
     And The /wallet-binding response should be returned in a timely manner 15000ms
     And The /wallet-binding endpoint response should have status 200
-    And The /wallet-binding endpoint endpoint response should have content-type: application/json header
+    And The /wallet-binding response should have "content-type": "application/json" header
     And The /wallet-binding endpoint response should match json schema with errors
     And The /wallet-binding response should contain errorCode property equals to "invalid_auth_challenge"

--- a/test/openAPI/features/wallet_consent.feature
+++ b/test/openAPI/features/wallet_consent.feature
@@ -17,7 +17,7 @@ Feature: The endpoint to send the accepted user claims and permitted scopes.
     Then Receive a response from the /linked-authorization/consent endpoint
     And The /linked-authorization/consent endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/consent endpoint response should have status 200
-    And The /linked-authorization/consent endpoint response should have content-type: application/json header
+    And The /linked-authorization/consent response should have "content-type": "application/json" header
     And The /linked-authorization/consent endpoint response should contain linkedTransactionId
     And The /linked-authorization/consent endpoint response should match json schema without errors
 
@@ -28,6 +28,6 @@ Feature: The endpoint to send the accepted user claims and permitted scopes.
     Then Receive a response from the /linked-authorization/consent endpoint
     And The /linked-authorization/consent endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/consent endpoint response should have status 200
-    And The /linked-authorization/consent endpoint response should have content-type: application/json header
+    And The /linked-authorization/consent response should have "content-type": "application/json" header
     And The /linked-authorization/consent endpoint response should match json schema
     And The /linked-authorization/consent response should contain errorCode property equals to "invalid_transaction_id"

--- a/test/openAPI/features/wallet_generate_link_auth_code.feature
+++ b/test/openAPI/features/wallet_generate_link_auth_code.feature
@@ -5,22 +5,22 @@ Feature: The endpoint to validates the link-code and its expiry and generates th
   Scenario: Successfully validates the link-code and its expiry and generates the link auth code smoke type test
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given linkCode and transactionId
+    When Send POST /linked-authorization/link-auth-code request with given linkedCode and transactionId and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with no errors
 
   @negative
-  Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkCode
+  Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkedCode
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given invalid linkCode
+    When Send POST /linked-authorization/link-auth-code request with given invalid linkedCode and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with errors
     And The /linked-authorization/link-auth-code response should contain errorCode property equals to "invalid_link_code"
 
@@ -28,23 +28,23 @@ Feature: The endpoint to validates the link-code and its expiry and generates th
   Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid transactionId
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given invalid transactionId
+    When Send POST /linked-authorization/link-auth-code request with given invalid transactionId and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with errors
     And The /linked-authorization/link-auth-code response should contain errorCode property equals to "invalid_transaction_id"
 
   @negative
-  Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkCode and transactionId
+  Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid linkedCode and transactionId
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given invalid linkCode and transactionId
+    When Send POST /linked-authorization/link-auth-code request with given invalid linkedCode and transactionId and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with errors
     And The /linked-authorization/link-auth-code response should contain errorCode property equals to "invalid_link_code"
 
@@ -52,11 +52,11 @@ Feature: The endpoint to validates the link-code and its expiry and generates th
   Scenario: Not able to validate the link-code and its expiry and generate the link auth code because of invalid requestTime
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given linkCode and transactionId and invalidRequestTime
+    When Send POST /linked-authorization/link-auth-code request with given linkedCode and transactionId and "X-XSRF-TOKEN" header and invalid requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with errors
     And The /linked-authorization/link-auth-code response should contain errorCode property equals to "invalid_request"
 
@@ -65,11 +65,11 @@ Feature: The endpoint to validates the link-code and its expiry and generates th
     Given Wants to validate the link-auth-code and generate the auth code
     And The link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
     And The second link code, transaction and authenticate is completed before POST /linked-authorization/link-auth-code
-    When Send POST /linked-authorization/link-auth-code request with given valid linkCode and transactionId
+    When Send POST /linked-authorization/link-auth-code request with given valid linkedCode and transactionId and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-auth-code endpoint response should have status 200
-    And The /linked-authorization/link-auth-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-auth-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response should match json schema with errors
     And The /linked-authorization/link-auth-code response should contain errorCode property equals to "invalid_link_code"
 
@@ -77,9 +77,9 @@ Feature: The endpoint to validates the link-code and its expiry and generates th
   Scenario: Not able to validate the link-code and its expiry because of reuse of the completed transaction_id
     Given Wants to validate the link-auth-code and generate the auth code
     And The first authorization flow for transactionID ends
-    When Send POST /linked-authorization/link-auth-code request with given linkCode and reused completed transactionId
+    When Send POST /linked-authorization/link-auth-code request with given linkedCode and reused completed transactionId and "X-XSRF-TOKEN" header and requestTime
     Then Receive a response for reuse transactionId from the /linked-authorization/link-auth-code endpoint
     And The /linked-authorization/link-auth-code endpoint response for reuse transactionId should have status 200
-    And The /linked-authorization/link-auth-code endpoint response for reuse transactionId should have content-type: application/json header
+    And The /linked-authorization/link-auth-code endpoint response for reuse transactionId should have "content-type": "application/json" header
     And The /linked-authorization/link-auth-code endpoint response for reuse transactionId should match json schema with errors
     And The /linked-authorization/link-auth-code response for reuse transactionId should contain errorCode property equals to "invalid_transaction_id"

--- a/test/openAPI/features/wallet_generate_link_code.feature
+++ b/test/openAPI/features/wallet_generate_link_code.feature
@@ -8,7 +8,7 @@ Feature: The endpoint to generate link code.
     Then Receive a response from the /linked-authorization/link-code endpoint
     And The /linked-authorization/link-code endpoint response should be returned in a timely manner 15000 ms
     And The /linked-authorization/link-code endpoint response should have status 200
-    And The /linked-authorization/link-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-code endpoint response should match json schema
     And The /linked-authorization/link-code response should contain transactionId property equals provided transactionId
 
@@ -19,7 +19,7 @@ Feature: The endpoint to generate link code.
     Then Receive a response from the /linked-authorization/link-code endpoint
     And The /linked-authorization/link-code endpoint response should be returned in a timely manner 15000 ms
     And The /linked-authorization/link-code endpoint response should have status 200
-    And The /linked-authorization/link-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-code endpoint response should match json schema with errors
     And The /linked-authorization/link-code response should contain errorCode property equals "invalid_transaction_id"
 
@@ -30,7 +30,7 @@ Feature: The endpoint to generate link code.
     Then Receive a response from the /linked-authorization/link-code endpoint
     And The /linked-authorization/link-code endpoint response should be returned in a timely manner 15000 ms
     And The /linked-authorization/link-code endpoint response should have status 200
-    And The /linked-authorization/link-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-code endpoint response should match json schema with errors
     And The /linked-authorization/link-code response should contain errorCode property equals "invalid_transaction_id"
 
@@ -38,10 +38,10 @@ Feature: The endpoint to generate link code.
   Scenario: Not able to generate link code because of reuse of the completed transaction_id
     Given Wants to generate link code
     And The first authorization flow for transactionId ends 
-    When Send POST /linked-authorization/link-code request with given X-XSRF-TOKEN header, XSRF-TOKEN cookie, reaused completed transactionId and requestTime
+    When Send POST /linked-authorization/link-code request with given X-XSRF-TOKEN header, XSRF-TOKEN cookie, already used completed transactionId and requestTime
     Then Receive a response for completed transactionId from the /linked-authorization/link-code endpoint
     And The /linked-authorization/link-code endpoint response for completed transactionId should have status 200
-    And The /linked-authorization/link-code endpoint response for completed transactionId should have content-type: application/json header
+    And The /linked-authorization/link-code endpoint response for completed transactionId should have "content-type": "application/json" header
     And The /linked-authorization/link-code endpoint response for completed transactionId should match json schema with errors
     And The /linked-authorization/link-code response for completed transactionId should contain errorCode property equals to "invalid_transaction_id"
 
@@ -52,7 +52,7 @@ Feature: The endpoint to generate link code.
     Then Receive a response from the /linked-authorization/link-code endpoint
     And The /linked-authorization/link-code endpoint response should be returned in a timely manner 15000 ms
     And The /linked-authorization/link-code endpoint response should have status 200
-    And The /linked-authorization/link-code endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-code response should have "content-type": "application/json" header
     And The /linked-authorization/link-code endpoint response should match json schema with errors
     And The /linked-authorization/link-code response should contain errorCode property equals "invalid_request"
 

--- a/test/openAPI/features/wallet_link_status.feature
+++ b/test/openAPI/features/wallet_link_status.feature
@@ -69,11 +69,11 @@ Feature: The endpoint to checks the status of link code.
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_link_code"
 
   @negative
-  Scenario: Not able to check the status of link code because of the link code connected to a different transaction id
+  Scenario: Not able to check the status of link code because of the linkCode connected to a different transactionId
     Given Wants to check the status of link code
     And The link code is generated
     And The second link code for diffrent transaction id is generated
-    When Send POST /linked-authorization/link-status request with given X-XSRF-TOKEN header, transactionId, link code connected to a different transaction id and requestTime
+    When Send POST /linked-authorization/link-status request with given X-XSRF-TOKEN header, transactionId, linkCode connected to a different transactionId and requestTime
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200

--- a/test/openAPI/features/wallet_link_transaction.feature
+++ b/test/openAPI/features/wallet_link_transaction.feature
@@ -1,36 +1,36 @@
 @method=POST @endpoint=/linked-authorization/link-transaction
-Feature: The endpoint to validates the link-code and its expiry and generates the linkTransactionId.
+Feature: The endpoint to validates the linkCode and its expiry and generates the linkTransactionId.
 
   @smoke @unit @positive
-  Scenario: Successfully validates the link-code and its expiry and generates the linkTransactionId smoke type test
-    Given Wants to validate the link-code and its expiry and generate the linkTransactionId
+  Scenario: Successfully validates the linkCode and its expiry and generates the linkTransactionId smoke type test
+    Given Wants to validate the linkCode and its expiry and generate the linkTransactionId
     And The link code is generated before POST /linked-authorization/link-transaction
-    When Send POST /linked-authorization/link-transaction request with given linkCode
+    When Send POST /linked-authorization/link-transaction request with given linkCode and requestTime
     Then Receive a response from the /linked-authorization/link-transaction endpoint
     And The /linked-authorization/link-transaction endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/link-transaction endpoint response should have status 200
-    And The /linked-authorization/link-transaction endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-transaction response should have "content-type": "application/json" header
     And The /linked-authorization/link-transaction endpoint response should match json schema with no error
 
   @negative
-  Scenario: Not able to validate the link-code and its expiry and generate the linkTransactionId because of invalid linkCode
-    Given Wants to validate the link-code and its expiry and generate the linkTransactionId
-    When Send POST /linked-authorization/link-transaction request with given invalid linkCode
+  Scenario: Not able to validate the linkCode and its expiry and generate the linkTransactionId because of invalid linkCode
+    Given Wants to validate the linkCode and its expiry and generate the linkTransactionId
+    When Send POST /linked-authorization/link-transaction request with given invalid linkCode and requestTime
     Then Receive a response from the /linked-authorization/link-transaction endpoint
     And The /linked-authorization/link-transaction endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/link-transaction endpoint response should have status 200
-    And The /linked-authorization/link-transaction endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-transaction response should have "content-type": "application/json" header
     And The /linked-authorization/link-transaction endpoint response should match json schema
     And The /linked-authorization/link-transaction response should contain errorCode property equals to "invalid_link_code"
 
   @negative
-  Scenario: Not able to validate the link-code and its expiry and generate the linkTransactionId because of expired linkCode
-    Given Wants to validate the link-code and its expiry and generate the linkTransactionId
+  Scenario: Not able to validate the linkCode and its expiry and generate the linkTransactionId because of expired linkCode
+    Given Wants to validate the linkCode and its expiry and generate the linkTransactionId
     And The link code is generated before POST /linked-authorization/link-transaction but wait 30s to be expired
-    When Send POST /linked-authorization/link-transaction request with given expired linkCode
+    When Send POST /linked-authorization/link-transaction request with given expired linkCode and requestTime
     Then Receive a response from the /linked-authorization/link-transaction endpoint
     And The /linked-authorization/link-transaction endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/link-transaction endpoint response should have status 200
-    And The /linked-authorization/link-transaction endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-transaction response should have "content-type": "application/json" header
     And The /linked-authorization/link-transaction endpoint response should match json schema
     And The /linked-authorization/link-transaction response should contain errorCode property equals to "invalid_link_code"

--- a/test/openAPI/features/wallet_linked_authenticate.feature
+++ b/test/openAPI/features/wallet_linked_authenticate.feature
@@ -9,7 +9,7 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response linkedTransactionId should be the same as sent in request
     And The /linked-authorization/authenticate endpoint response should match json schema without errors
 
@@ -20,7 +20,7 @@ Feature: The endpoint to check the correctness of the data.
     And Receive a response from the /linked-authorization/authenticate endpoint for reused link code
     And The /linked-authorization/authenticate endpoint response for reused link code should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response for reused link code should have status 200
-    And The /linked-authorization/authenticate endpoint response for reused link code should have content-type: application/json header
+    And The /linked-authorization/authenticate endpoint response for reused link code should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response for reused link code should match json schema with errors
     And The /linked-authorization/authenticate response for reused link code should contain errorCode property equals to "invalid_transaction_id"
 
@@ -31,7 +31,7 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response should match json schema with errors
     And The /linked-authorization/authenticate response should contain errorCode property equals to "invalid_transaction_id"
 
@@ -42,7 +42,7 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response should match json schema with errors
     And The /linked-authorization/authenticate response should contain errorCode property equals to "invalid_identifier"
 
@@ -53,7 +53,7 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response should match json schema with errors
     And The /linked-authorization/authenticate response should contain errorCode property equals to "invalid_no_of_challenges"
 
@@ -65,7 +65,7 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response should match json schema with errors
     And The /linked-authorization/authenticate response should contain errorCode property equals to "invalid_request"
 
@@ -77,6 +77,6 @@ Feature: The endpoint to check the correctness of the data.
     Then Receive a response from the /linked-authorization/authenticate endpoint
     And The /linked-authorization/authenticate endpoint response should be returned in a timely manner 15000ms
     And The /linked-authorization/authenticate endpoint response should have status 200
-    And The /linked-authorization/authenticate endpoint response should have content-type: application/json header
+    And The /linked-authorization/authenticate response should have "content-type": "application/json" header
     And The /linked-authorization/authenticate endpoint response should match json schema with errors
     And The /linked-authorization/authenticate response should contain errorCode property equals to "auth_failed"


### PR DESCRIPTION
**Ticket:**
https://govstack-global.atlassian.net/browse/TECH-863

**Changes:**
1. Lack of content type as a string - it should be a string to automatically generate JS tests.
   - Correction: "application/json"

2. The request body is in the format application/x-www-form-urlencoded, which is not used elsewhere.
   - Correction: The POST request body has a content type of "application/x-www-form-urlencoded."

3. The body parameters of the endpoint are in snake case, not camel case as we have now.
   - Correction: Camel case standard for body key names.

4. Missing required body parameters in the positive response.
   - Missing parameter: id_token
   - Correction: "id_token": "string", "access_token": "string", "token_type": "Bearer", "expires_in": 0

5. Missing tags.
   - Missing tags: @positive + @unit

6. Lack of assertion for positive tests in the response.
   - Correction: Include assertions with the set parameters.

7. No information about the REQUIRED header.
   - Missing header: Header X-XSRF-TOKEN is required.

8. RequestTime is required in the request body.
   - Correction: "requestTime": "string"

9. Incorrect parameter name: linkCode
   - Correction: Change to linkedCode

10. Spelling error: reaused completed transactionId
    - Correction: Change to already used completed transactionId

11. Missing parameter - written as separate words.
    - Correction: Change "link code connected to a different transactionId" to "linkCode connected to a different transactionId"
    
**Testing:**
All updated tests are functioning as expected. One test was not working initially, and it remains unresolved. Addressing this issue is outside the scope of this PR and will require further investigation.