### PR TITLE
TECH-863: changed content-type value to string and added spec() variable

### DIFF
--- a/test/openAPI/features/support/helpers/helpers.js
+++ b/test/openAPI/features/support/helpers/helpers.js
@@ -109,7 +109,7 @@ module.exports = {
     ],
   },
   // oidc_well_known_jwks
-  oidcWellKnownJWKSEndpoint: '.well-known/jwks.json',
+  oidcWellKnownJWKSEndpoint: 'oauth/.well-known/jwks.json',
   oidcWellKnownJWKSResponseSchema: {
     type: 'object',
     properties: {

--- a/test/openAPI/features/support/helpers/helpers.js
+++ b/test/openAPI/features/support/helpers/helpers.js
@@ -109,7 +109,7 @@ module.exports = {
     ],
   },
   // oidc_well_known_jwks
-  oidcWellKnownJWKSEndpoint: 'oauth/.well-known/jwks.json',
+  oidcWellKnownJWKSEndpoint: '.well-known/jwks.json',
   oidcWellKnownJWKSResponseSchema: {
     type: 'object',
     properties: {

--- a/test/openAPI/features/support/oidc_well_known_jwks.js
+++ b/test/openAPI/features/support/oidc_well_known_jwks.js
@@ -14,6 +14,8 @@ chai.use(require('chai-json-schema'));
 const baseUrl = localhost + oidcWellKnownJWKSEndpoint;
 const endpointTag = { tags: `@endpoint=/${oidcWellKnownJWKSEndpoint}` };
 
+let specJWKS;
+
 Before(endpointTag, () => {
   specJWKS = spec();
 });

--- a/test/openAPI/features/support/oidc_well_known_openid_configuration.js
+++ b/test/openAPI/features/support/oidc_well_known_openid_configuration.js
@@ -14,6 +14,8 @@ chai.use(require('chai-json-schema'));
 const baseUrl = localhost + oidcWellKnownOpenidConfigurationEndpoint;
 const endpointTag = { tags: `@endpoint=/${oidcWellKnownOpenidConfigurationEndpoint}` };
 
+let specOpenidConfiguration;
+
 Before(endpointTag, () => {
   specOpenidConfiguration = spec();
 });

--- a/test/openAPI/features/support/wallet_link_status.js
+++ b/test/openAPI/features/support/wallet_link_status.js
@@ -91,9 +91,11 @@ Then(/^The \/linked-authorization\/link-status endpoint response should have sta
 });
 
 Then(
-  /^The \/linked-authorization\/link-status endpoint response should have content-type: application\/json header$/,
-  () => {
-    specWalletLinkStatus.response().should.have.header(contentTypeHeader.key, contentTypeHeader.value);
+  /^The \/linked-authorization\/link-status response should have "([^"]*)": "([^"]*)" header$/,
+  (key, value) => {
+    specWalletLinkStatus
+      .response()
+      .should.have.headerContains(key, value);
   }
 );
 

--- a/test/openAPI/features/wallet_link_status.feature
+++ b/test/openAPI/features/wallet_link_status.feature
@@ -9,7 +9,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with no errors
     And The /linked-authorization/link-status response should contain transactionId property equals provided transactionId
 
@@ -20,7 +20,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_transaction_id"
 
@@ -31,7 +31,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_transaction_id"
 
@@ -42,7 +42,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_transaction_id"
 
@@ -53,7 +53,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_link_code"
     
@@ -64,7 +64,7 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_link_code"
 
@@ -77,6 +77,6 @@ Feature: The endpoint to checks the status of link code.
     Then Receive a response from the /linked-authorization/link-status endpoint
     And The /linked-authorization/link-status endpoint response should be returned in a timely manner 25000 ms
     And The /linked-authorization/link-status endpoint response should have status 200
-    And The /linked-authorization/link-status endpoint response should have content-type: application/json header
+    And The /linked-authorization/link-status response should have "content-type": "application/json" header
     And The /linked-authorization/link-status endpoint response should match json schema with errors
     And The /linked-authorization/link-status response should contain errorCode property equals to "invalid_link_code"


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-863

Changes:
- content-type is now in form of a string
- spec() varaible is now initialized before being used